### PR TITLE
Teach EtlMultiOutputFormat to use snappy compression

### DIFF
--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -58,7 +58,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.1</version>
-     </dependency>
+    </dependency>
   </dependencies>
 
   <build>

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitterTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitterTest.java
@@ -86,6 +86,17 @@ public class EtlMultiOutputCommitterTest implements Partitioner {
         assertTrue(EtlMultiOutputFormat.getPartitioner(taskAttemptContext, "test-topic") instanceof EtlMultiOutputCommitterTest);
     }
 
+    @Test
+    public void testDefaultOutputCodecIsDeflate() {
+        assertEquals("deflate", EtlMultiOutputFormat.getEtlOutputCodec(taskAttemptContext));
+    }
+    
+    @Test
+    public void testSetOutputCodec() {
+        EtlMultiOutputFormat.setEtlOutputCodec(taskAttemptContext, "snappy");
+        assertEquals("snappy", EtlMultiOutputFormat.getEtlOutputCodec(taskAttemptContext));
+    }
+
     public long convertTime(long time) {
         long outfilePartitionMs = EtlMultiOutputFormat.getEtlOutputFileTimePartitionMins(taskAttemptContext) * 60000L;
         return DateUtils.getPartition(outfilePartitionMs, time);

--- a/camus-example/src/main/resources/camus.properties
+++ b/camus-example/src/main/resources/camus.properties
@@ -55,8 +55,12 @@ etl.hourly=hourly
 etl.daily=daily
 etl.ignore.schema.errors=false
 
-etl.default.timezone=America/Los_Angeles
+# configure output compression for deflate or snappy. Defaults to deflate
+etl.output.codec=deflate
 etl.deflate.level=6
+#etl.output.codec=snappy
+
+etl.default.timezone=America/Los_Angeles
 etl.output.file.time.partition.mins=60
 etl.keep.count.files=false
 etl.execution.history.max.of.quota=.8


### PR DESCRIPTION
Set etl.output.codec=snappy to enable snappy compression
