### PR TITLE
Flag to post counts to kafka/Control number of message decode exceptions printed

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -71,8 +71,9 @@ public class CamusJob extends Configured implements Tool {
     public static final String KAFKA_MONITOR_TIER = "kafka.monitor.tier";
     public static final String CAMUS_MESSAGE_ENCODER_CLASS = "camus.message.encoder.class";
     public static final String BROKER_URI_FILE = "brokers.uri";
-
-    private final Properties props;
+    public static final String POST_TRACKING_COUNTS_TO_KAFKA = "post.tracking.counts.to.kafka";
+   
+ private final Properties props;
 
     public CamusJob() {
         this.props = new Properties();
@@ -320,10 +321,12 @@ public class CamusJob extends Configured implements Tool {
             }
 
             writeBrokers(fs, job, brokerURI);
-
-            for (EtlCounts count : countsMap.values()) {
-                count.postTrackingCountToKafka(props.getProperty(KAFKA_MONITOR_TIER), brokerURI);
+	    if(getPostTrackingCountsToKafka(job)) {
+            	for (EtlCounts count : countsMap.values()) {
+            		count.postTrackingCountToKafka(props.getProperty(KAFKA_MONITOR_TIER), brokerURI);
+           	 }
             }
+
         }
 
         // echo any errors in the error files. hopefully there are none
@@ -547,5 +550,9 @@ public class CamusJob extends Configured implements Tool {
 
         run();
         return 0;
+    }
+
+    public static boolean getPostTrackingCountsToKafka(Job job){
+    	return job.getConfiguration().getBoolean(POST_TRACKING_COUNTS_TO_KAFKA, true);
     }
 }

--- a/camus-example/src/main/resources/camus.properties
+++ b/camus-example/src/main/resources/camus.properties
@@ -44,6 +44,16 @@ kafka.max.pull.minutes.per.task=-1
 kafka.blacklist.topics=
 kafka.whitelist.topics=
 
+
+#Stops the mapper from getting inundated with Decoder exceptions for the same topic
+#Default value is set to 10
+max.decoder.exceptions.to.print=5
+
+#Controls the submitting of counts to Kafka
+#Default value set to true
+post.tracking.counts.to.kafka=true
+
+
 # everything below this point can be ignored for the time being, will provide more documentation down the road
 ##########################
 etl.run.tracking.post=false


### PR DESCRIPTION
Added flag to control posting of counts to kafka audit.
This is done by setting 'post.tracking.counts.to.kafka' to true or false in the configuration file.
Defaults to true.

During decoding of messages, exceptions were being printed for all records of a topic.
The number of exceptions printed can now be controlled by setting the 'max.decoder.exceptions.to.print' in the configuration file.
Defaults to 10.
