### PR TITLE
Add support for other serialization formats. You'll have to implement th...

### DIFF
--- a/camus-api/src/main/java/com/linkedin/camus/coders/CamusWrapper.java
+++ b/camus-api/src/main/java/com/linkedin/camus/coders/CamusWrapper.java
@@ -7,7 +7,7 @@ import org.apache.hadoop.io.Writable;
 /**
  * Container for messages.  Enables the use of a custom message decoder with knowledge
  * of where these values are stored in the message schema
- * 
+ *
  * @author kgoodhop
  *
  * @param <R> The type of decoded payload
@@ -20,11 +20,11 @@ public class CamusWrapper<R> {
     public CamusWrapper(R record) {
         this(record, System.currentTimeMillis());
     }
-    
+
     public CamusWrapper(R record, long timestamp) {
         this(record, timestamp, "unknown_server", "unknown_service");
     }
-    
+
     public CamusWrapper(R record, long timestamp, String server, String service) {
         this.record = record;
         this.timestamp = timestamp;
@@ -58,14 +58,14 @@ public class CamusWrapper<R> {
 
     /**
      * Get a value for partitions
-     * @returns the value for the given key
+     * @return the value for the given key
      */
     public Writable get(Writable key) {
         return partitionMap.get(key);
     }
 
     /**
-     * Get all the parititon key/partitionMap
+     * Get all the partition key/partitionMap
      */
     public MapWritable getPartitionMap() {
         return partitionMap;

--- a/camus-api/src/main/java/com/linkedin/camus/coders/MessageDecoder.java
+++ b/camus-api/src/main/java/com/linkedin/camus/coders/MessageDecoder.java
@@ -3,8 +3,8 @@ package com.linkedin.camus.coders;
 import java.util.Properties;
 
 /**
- * Decoder interface. Implemenations should return a CamusWrapper with timestamp
- * set at the very least.  Camus will instantiate a descendent of this class 
+ * Decoder interface. Implementations should return a CamusWrapper with timestamp
+ * set at the very least.  Camus will instantiate a descendent of this class
  * based on the property ccamus.message.decoder.class.
  * @author kgoodhop
  *
@@ -14,7 +14,7 @@ import java.util.Properties;
 public abstract class MessageDecoder<M,R> {
 	protected Properties props;
 	protected String topicName;
-	
+
 	public void init(Properties props, String topicName){
 	    this.props = props;
         this.topicName = topicName;

--- a/camus-api/src/main/java/com/linkedin/camus/etl/RecordWriterProvider.java
+++ b/camus-api/src/main/java/com/linkedin/camus/etl/RecordWriterProvider.java
@@ -1,0 +1,20 @@
+package com.linkedin.camus.etl;
+
+import com.linkedin.camus.coders.CamusWrapper;
+import java.io.IOException;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+
+/**
+ *
+ *
+ */
+public interface RecordWriterProvider {
+
+    String getFilenameExtension();
+
+    RecordWriter<IEtlKey, CamusWrapper> getDataRecordWriter(
+            TaskAttemptContext context, String fileName, CamusWrapper data, FileOutputCommitter committer) throws IOException,
+            InterruptedException;
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/coders/DefaultPartitioner.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/coders/DefaultPartitioner.java
@@ -26,6 +26,5 @@ public class DefaultPartitioner implements Partitioner {
         DateTime bucket = new DateTime(Long.valueOf(encodedPartition));
         sb.append(bucket.toString(OUTPUT_DATE_FORMAT));
         return sb.toString();
-
     }
 }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/AvroRecordWriterProvider.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/AvroRecordWriterProvider.java
@@ -1,0 +1,67 @@
+package com.linkedin.camus.etl.kafka.common;
+
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.etl.IEtlKey;
+import com.linkedin.camus.etl.RecordWriterProvider;
+import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
+import java.io.IOException;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+
+/**
+ *
+ *
+ */
+public class AvroRecordWriterProvider implements RecordWriterProvider {
+    public final static String EXT = ".avro";
+
+    @Override
+    public String getFilenameExtension() {
+        return EXT;
+    }
+
+    @Override
+    public RecordWriter<IEtlKey, CamusWrapper> getDataRecordWriter(
+            TaskAttemptContext context,
+            String fileName,
+            CamusWrapper data,
+            FileOutputCommitter committer) throws IOException, InterruptedException {
+        final DataFileWriter<Object> writer = new DataFileWriter<Object>(
+                new SpecificDatumWriter<Object>());
+
+        if (FileOutputFormat.getCompressOutput(context)) {
+            if ("snappy".equals(EtlMultiOutputFormat.getEtlOutputCodec(context))) {
+                writer.setCodec(CodecFactory.snappyCodec());
+            } else {
+                int level = EtlMultiOutputFormat.getEtlDeflateLevel(context);
+                writer.setCodec(CodecFactory.deflateCodec(level));
+            }
+        }
+
+        Path path = committer.getWorkPath();
+        path = new Path(path, EtlMultiOutputFormat.getUniqueFile(context, fileName, EXT));
+        writer.create(((GenericRecord) data.getRecord()).getSchema(),
+                path.getFileSystem(context.getConfiguration()).create(path));
+
+        writer.setSyncInterval(EtlMultiOutputFormat.getEtlAvroWriterSyncInterval(context));
+
+        return new RecordWriter<IEtlKey, CamusWrapper>() {
+            @Override
+            public void write(IEtlKey ignore, CamusWrapper data) throws IOException {
+                writer.append(data.getRecord());
+            }
+
+            @Override
+            public void close(TaskAttemptContext arg0) throws IOException, InterruptedException {
+                writer.close();
+            }
+        };
+    }
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
@@ -23,7 +23,7 @@ import com.linkedin.camus.etl.kafka.CamusJob;
 /**
  * Poorly named class that handles kafka pull events within each
  * KafkaRecordReader.
- * 
+ *
  * @author Richard Park
  */
 public class KafkaReader {
@@ -46,7 +46,7 @@ public class KafkaReader {
 	private int fetchBufferSize;
 
 	/**
-	 * Construct using the json represention of the kafka request
+	 * Construct using the json representation of the kafka request
 	 */
 	public KafkaReader(TaskAttemptContext context, EtlRequest request,
 			int clientTimeout, int fetchBufferSize) throws Exception {
@@ -90,7 +90,7 @@ public class KafkaReader {
 	/**
 	 * Fetches the next Kafka message and stuffs the results into the key and
 	 * value
-	 * 
+	 *
 	 * @param key
 	 * @param payload
 	 * @param pKey
@@ -108,7 +108,7 @@ public class KafkaReader {
 			byte[] bytes = new byte[origSize];
 			buf.get(bytes, buf.position(), origSize);
 			payload.set(bytes, 0, origSize);
-			
+
 			buf = message.key();
 			if(buf != null){
 				origSize = buf.remaining();
@@ -133,7 +133,7 @@ public class KafkaReader {
 
 	/**
 	 * Creates a fetch request.
-	 * 
+	 *
 	 * @return false if there's no more fetches
 	 * @throws IOException
 	 */
@@ -200,14 +200,14 @@ public class KafkaReader {
 					System.out.println("Skipping offset : " + skippedMessage.offset());
 					skipped --;
 				}
-				
+
 				if (!messageIter.hasNext()) {
 					System.out
 							.println("No more data left to process. Returning false");
 					messageIter = null;
 					return false;
 				}
-				
+
 				return true;
 			}
 		} catch (Exception e) {
@@ -220,7 +220,7 @@ public class KafkaReader {
 
 	/**
 	 * Closes this context
-	 * 
+	 *
 	 * @throws IOException
 	 */
 	public void close() throws IOException {
@@ -232,7 +232,7 @@ public class KafkaReader {
 	/**
 	 * Returns the total bytes that will be fetched. This is calculated by
 	 * taking the diffs of the offsets
-	 * 
+	 *
 	 * @return
 	 */
 	public long getTotalBytes() {
@@ -241,7 +241,7 @@ public class KafkaReader {
 
 	/**
 	 * Returns the total bytes that have been fetched so far
-	 * 
+	 *
 	 * @return
 	 */
 	public long getReadBytes() {
@@ -250,7 +250,7 @@ public class KafkaReader {
 
 	/**
 	 * Returns the number of events that have been read r
-	 * 
+	 *
 	 * @return
 	 */
 	public long getCount() {
@@ -259,7 +259,7 @@ public class KafkaReader {
 
 	/**
 	 * Returns the fetch time of the last fetch in ms
-	 * 
+	 *
 	 * @return
 	 */
 	public long getFetchTime() {
@@ -268,7 +268,7 @@ public class KafkaReader {
 
 	/**
 	 * Returns the totalFetchTime in ms
-	 * 
+	 *
 	 * @return
 	 */
 	public long getTotalFetchTime() {

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -1,5 +1,12 @@
 package com.linkedin.camus.etl.kafka.mapred;
 
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.coders.MessageDecoder;
+import com.linkedin.camus.etl.kafka.CamusJob;
+import com.linkedin.camus.etl.kafka.coders.KafkaAvroMessageDecoder;
+import com.linkedin.camus.etl.kafka.coders.MessageDecoderFactory;
+import com.linkedin.camus.etl.kafka.common.EtlKey;
+import com.linkedin.camus.etl.kafka.common.EtlRequest;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -13,14 +20,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-
 import kafka.common.ErrorMapping;
 import kafka.javaapi.PartitionMetadata;
 import kafka.javaapi.TopicMetadata;
 import kafka.javaapi.TopicMetadataRequest;
 import kafka.javaapi.consumer.SimpleConsumer;
-
-import org.apache.avro.mapred.AvroWrapper;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -36,16 +40,10 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.log4j.Logger;
 
-import com.linkedin.camus.etl.kafka.CamusJob;
-import com.linkedin.camus.etl.kafka.coders.KafkaAvroMessageDecoder;
-import com.linkedin.camus.etl.kafka.coders.MessageDecoderFactory;
-import com.linkedin.camus.etl.kafka.common.EtlKey;
-import com.linkedin.camus.etl.kafka.common.EtlRequest;
-
 /**
  * Input format for a Kafka pull job.
  */
-public class EtlInputFormat extends InputFormat<EtlKey, AvroWrapper<Object>> {
+public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 
 	public static final String KAFKA_BLACKLIST_TOPIC = "kafka.blacklist.topics";
 	public static final String KAFKA_WHITELIST_TOPIC = "kafka.whitelist.topics";
@@ -66,7 +64,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, AvroWrapper<Object>> {
 	private final Logger log = Logger.getLogger(getClass());
 
 	@Override
-	public RecordReader<EtlKey, AvroWrapper<Object>> createRecordReader(
+	public RecordReader<EtlKey, CamusWrapper> createRecordReader(
 			InputSplit split, TaskAttemptContext context) throws IOException,
 			InterruptedException {
 		return new EtlRecordReader(split, context);
@@ -248,7 +246,6 @@ public class EtlInputFormat extends InputFormat<EtlKey, AvroWrapper<Object>> {
 	}
 
 	private boolean createMessageDecoder(JobContext context, String topic) {
-
 		try {
 			MessageDecoderFactory.createMessageDecoder(context, topic);
 			return true;
@@ -482,14 +479,13 @@ public class EtlInputFormat extends InputFormat<EtlKey, AvroWrapper<Object>> {
 	}
 
 	public static void setMessageDecoderClass(JobContext job,
-			Class<KafkaAvroMessageDecoder> cls) {
-		job.getConfiguration().setClass(CAMUS_MESSAGE_DECODER_CLASS, cls,
-				KafkaAvroMessageDecoder.class);
+			Class<MessageDecoder> cls) {
+		job.getConfiguration().setClass(CAMUS_MESSAGE_DECODER_CLASS, cls, MessageDecoder.class);
 	}
 
-	public static Class<KafkaAvroMessageDecoder> getMessageDecoderClass(
+	public static Class<MessageDecoder> getMessageDecoderClass(
 			JobContext job) {
-		return (Class<KafkaAvroMessageDecoder>) job.getConfiguration()
+		return (Class<MessageDecoder>) job.getConfiguration()
 				.getClass(CAMUS_MESSAGE_DECODER_CLASS,
 						KafkaAvroMessageDecoder.class);
 	}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
@@ -1,5 +1,15 @@
 package com.linkedin.camus.etl.kafka.mapred;
 
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.coders.Partitioner;
+import com.linkedin.camus.etl.IEtlKey;
+import com.linkedin.camus.etl.RecordWriterProvider;
+import com.linkedin.camus.etl.kafka.coders.DefaultPartitioner;
+import com.linkedin.camus.etl.kafka.common.AvroRecordWriterProvider;
+import com.linkedin.camus.etl.kafka.common.DateUtils;
+import com.linkedin.camus.etl.kafka.common.EtlCounts;
+import com.linkedin.camus.etl.kafka.common.EtlKey;
+import com.linkedin.camus.etl.kafka.common.ExceptionWritable;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -9,14 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import com.linkedin.camus.coders.Partitioner;
-import org.apache.avro.Schema;
-import org.apache.avro.file.CodecFactory;
-import org.apache.avro.file.DataFileWriter;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.mapred.AvroWrapper;
-import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -33,15 +35,9 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 
-import com.linkedin.camus.etl.kafka.coders.DefaultPartitioner;
-import com.linkedin.camus.etl.kafka.common.DateUtils;
-import com.linkedin.camus.etl.kafka.common.EtlCounts;
-import com.linkedin.camus.etl.kafka.common.EtlKey;
-import com.linkedin.camus.etl.kafka.common.ExceptionWritable;
-
 /**
  * MultipleAvroOutputFormat.
- * 
+ *
  * File names are determined by output keys.
  */
 
@@ -60,10 +56,10 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
     public static final String ETL_DEFAULT_PARTITIONER_CLASS = "etl.partitioner.class";
     public static final String ETL_OUTPUT_CODEC = "etl.output.codec";
     public static final String ETL_DEFAULT_OUTPUT_CODEC = "deflate";
+    public static final String ETL_RECORD_WRITER_PROVIDER_CLASS = "etl.record.writer.provider.class";
 
     public static final DateTimeFormatter FILE_DATE_FORMATTER = DateUtils
             .getDateTimeFormatter("YYYYMMddHH");
-    public final static String EXT = ".avro";
     public static final String OFFSET_PREFIX = "offsets";
     public static final String ERRORS_PREFIX = "errors";
     public static final String COUNTS_PREFIX = "counts";
@@ -83,39 +79,18 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
         return new MultiEtlRecordWriter(context);
     }
 
-    private RecordWriter<EtlKey, AvroWrapper<Object>> getDataRecordWriter(
-            TaskAttemptContext context, String name, String schema) throws IOException,
+    private RecordWriter<IEtlKey, CamusWrapper> getDataRecordWriter(
+            TaskAttemptContext context, String fileName, CamusWrapper value) throws IOException,
             InterruptedException {
-        final DataFileWriter<Object> writer = new DataFileWriter<Object>(
-                new SpecificDatumWriter<Object>());
-
-        if (FileOutputFormat.getCompressOutput(context)) {
-            if ("snappy".equals(getEtlOutputCodec(context))) {
-                writer.setCodec(CodecFactory.snappyCodec());
-            } else {
-                int level = getEtlDeflateLevel(context);
-                writer.setCodec(CodecFactory.deflateCodec(level));
-            }
+        RecordWriterProvider recordWriterProvider = null;
+        try {
+            recordWriterProvider = getRecordWriterProviderClass(context).newInstance();
+        } catch (InstantiationException e) {
+            throw new IllegalStateException(e);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException(e);
         }
-
-        Path path = committer.getWorkPath();
-        path = new Path(path, getUniqueFile(context, name, EXT));
-        writer.create(Schema.parse(schema),
-                path.getFileSystem(context.getConfiguration()).create(path));
-
-        writer.setSyncInterval(getEtlAvroWriterSyncInterval(context));
-
-        return new RecordWriter<EtlKey, AvroWrapper<Object>>() {
-            @Override
-            public void write(EtlKey ignore, AvroWrapper<Object> data) throws IOException {
-                writer.append(data.datum());
-            }
-
-            @Override
-            public void close(TaskAttemptContext arg0) throws IOException, InterruptedException {
-                writer.close();
-            }
-        };
+        return recordWriterProvider.getDataRecordWriter(context, fileName, value, committer);
     }
 
     @Override
@@ -127,6 +102,17 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
         return committer;
     }
 
+    public static void setRecordWriterProviderClass(JobContext job, Class<RecordWriterProvider> recordWriterProviderClass) {
+        job.getConfiguration().setClass(ETL_RECORD_WRITER_PROVIDER_CLASS, recordWriterProviderClass, RecordWriterProvider.class);
+    }
+
+    public static Class<RecordWriterProvider> getRecordWriterProviderClass(
+            JobContext job) {
+        return (Class<RecordWriterProvider>) job.getConfiguration()
+                .getClass(ETL_RECORD_WRITER_PROVIDER_CLASS,
+                        AvroRecordWriterProvider.class);
+    }
+
     public static void setDefaultTimeZone(JobContext job, String tz) {
         job.getConfiguration().set(ETL_DEFAULT_TIMEZONE, tz);
     }
@@ -134,7 +120,7 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
     public static String getDefaultTimeZone(JobContext job) {
         return job.getConfiguration().get(ETL_DEFAULT_TIMEZONE, "America/Los_Angeles");
     }
-    
+
     public static void setDestinationPath(JobContext job, Path dest) {
         job.getConfiguration().set(ETL_DESTINATION_PATH, dest.toString());
     }
@@ -170,7 +156,7 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
     public static void setEtlDeflateLevel(JobContext job, int val) {
         job.getConfiguration().setInt(ETL_DEFLATE_LEVEL, val);
     }
-    
+
     public static void setEtlOutputCodec(JobContext job, String codec) {
         job.getConfiguration().set(ETL_OUTPUT_CODEC, codec);
     }
@@ -245,7 +231,7 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
         private String currentTopic = "";
         private long beginTimeStamp = 0;
 
-        private HashMap<String, RecordWriter<EtlKey, AvroWrapper<Object>>> dataWriters = new HashMap<String, RecordWriter<EtlKey, AvroWrapper<Object>>>();
+        private HashMap<String, RecordWriter<IEtlKey, CamusWrapper>> dataWriters = new HashMap<String, RecordWriter<IEtlKey, CamusWrapper>>();
 
         public MultiEtlRecordWriter(TaskAttemptContext context) throws IOException,
                 InterruptedException {
@@ -273,14 +259,14 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
 
         @Override
         public void write(EtlKey key, Object val) throws IOException, InterruptedException {
-            if (val instanceof AvroWrapper<?>) {
+            if (val instanceof CamusWrapper<?>) {
                 if (key.getTime() < beginTimeStamp) {
                     // ((Mapper.Context)context).getCounter("total",
                     // "skip-old").increment(1);
                     committer.addOffset(key);
                 } else {
                     if (!key.getTopic().equals(currentTopic)) {
-                        for (RecordWriter<EtlKey, AvroWrapper<Object>> writer : dataWriters
+                        for (RecordWriter<IEtlKey, CamusWrapper> writer : dataWriters
                                 .values()) {
                             writer.close(context);
                         }
@@ -289,13 +275,12 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
                     }
 
                     committer.addCounts(key);
-                    AvroWrapper<Object> value = (AvroWrapper<Object>) val;
+                    CamusWrapper value = (CamusWrapper) val;
                     String workingFileName = getWorkingFileName(context, key);
                     if (!dataWriters.containsKey(workingFileName)) {
                         dataWriters.put(
                                 workingFileName,
-                                getDataRecordWriter(context, workingFileName,
-                                        ((GenericRecord) value.datum()).getSchema().toString()));
+                                getDataRecordWriter(context, workingFileName, value));
                     }
                     dataWriters.get(workingFileName).write(key, value);
                 }
@@ -309,12 +294,14 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
     }
 
     public class EtlMultiOutputCommitter extends FileOutputCommitter {
-        Pattern workingFileMetadataPattern = Pattern.compile("data\\.([^\\.]+)\\.(\\d+)\\.(\\d+)\\.([^\\.]+)-m-\\d+.avro");
+        Pattern workingFileMetadataPattern;
 
         HashMap<String, EtlCounts> counts = new HashMap<String, EtlCounts>();
         HashMap<String, EtlKey> offsets = new HashMap<String, EtlKey>();
 
         TaskAttemptContext context;
+        private final RecordWriterProvider recordWriterProvider;
+
 
         public void addCounts(EtlKey key) throws IOException {
             String workingFileName = getWorkingFileName(context, key);
@@ -334,11 +321,17 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
                 throws IOException {
             super(outputPath, context);
             this.context = context;
+            try {
+                recordWriterProvider = getRecordWriterProviderClass(context).newInstance();
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+            workingFileMetadataPattern = Pattern.compile("data\\.([^\\.]+)\\.(\\d+)\\.(\\d+)\\.([^\\.]+)-m-\\d+" + recordWriterProvider.getFilenameExtension());
         }
 
         @Override
         public void commitTask(TaskAttemptContext context) throws IOException {
-        	
+
         	ArrayList<Map<String,Object>> allCountObject = new ArrayList<Map<String,Object>>();
             FileSystem fs = FileSystem.get(context.getConfiguration());
             if (isRunMoveData(context)) {
@@ -363,11 +356,11 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
 
                         if (isRunTrackingPost(context)) {
                                 count.writeCountsToHDFS(allCountObject, fs, new Path(workPath, COUNTS_PREFIX + "."
-                                        + dest.getName().replace(EXT, "")));
+                                        + dest.getName().replace(recordWriterProvider.getFilenameExtension(), "")));
                         }
                     }
                 }
-             
+
                 Path tempPath = new Path(workPath, "counts." + context.getConfiguration().get("mapred.task.id"));
                 OutputStream outputStream = new BufferedOutputStream(fs.create(tempPath));
                 ObjectMapper mapper= new ObjectMapper();
@@ -405,7 +398,7 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
             return partitionedPath +
                         "/" + topic + "." + leaderId + "." + partition +
                         "." + count+
-                        "." + offset + EXT;
+                        "." + offset + recordWriterProvider.getFilenameExtension();
         }
     }
 }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -1,22 +1,17 @@
 package com.linkedin.camus.etl.kafka.mapred;
 
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.coders.MessageDecoder;
+import com.linkedin.camus.etl.kafka.CamusJob;
+import com.linkedin.camus.etl.kafka.coders.MessageDecoderFactory;
+import com.linkedin.camus.etl.kafka.common.EtlKey;
+import com.linkedin.camus.etl.kafka.common.EtlRequest;
+import com.linkedin.camus.etl.kafka.common.ExceptionWritable;
+import com.linkedin.camus.etl.kafka.common.KafkaReader;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
-
 import kafka.message.Message;
-
-import org.apache.avro.generic.GenericData.Record;
-import org.apache.avro.mapred.AvroWrapper;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ChecksumException;
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.JobContext;
@@ -26,17 +21,7 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.joda.time.DateTime;
 
-import com.linkedin.camus.coders.CamusWrapper;
-import com.linkedin.camus.coders.MessageDecoder;
-import com.linkedin.camus.etl.kafka.CamusJob;
-import com.linkedin.camus.etl.kafka.coders.KafkaAvroMessageDecoder;
-import com.linkedin.camus.etl.kafka.coders.MessageDecoderFactory;
-import com.linkedin.camus.etl.kafka.common.EtlKey;
-import com.linkedin.camus.etl.kafka.common.EtlRequest;
-import com.linkedin.camus.etl.kafka.common.ExceptionWritable;
-import com.linkedin.camus.etl.kafka.common.KafkaReader;
-
-public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
+public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     private static final String PRINT_MAX_DECODER_EXCEPTIONS = "max.decoder.exceptions.to.print";
     private TaskAttemptContext context;
 
@@ -47,11 +32,11 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
     private long readBytes = 0;
 
     private boolean skipSchemaErrors = false;
-    private MessageDecoder<byte[], Record> decoder;
+    private MessageDecoder decoder;
     private final BytesWritable msgValue = new BytesWritable();
     private final BytesWritable msgKey = new BytesWritable();
     private final EtlKey key = new EtlKey();
-    private AvroWrapper<Object> value = new AvroWrapper<Object>(new Object());
+    private CamusWrapper value;
 
     private int maxPullHours = 0;
     private int exceptionCount = 0;
@@ -65,10 +50,8 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
 
     /**
      * Record reader to fetch directly from Kafka
-     * 
+     *
      * @param split
-     * @param job
-     * @param reporter
      * @throws IOException
      * @throws InterruptedException
      */
@@ -77,7 +60,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
         initialize(split, context);
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void initialize(InputSplit split, TaskAttemptContext context) throws IOException,
             InterruptedException {
@@ -176,14 +159,14 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
     }
 
     @Override
-    public AvroWrapper<Object> getCurrentValue() throws IOException, InterruptedException {
+    public CamusWrapper getCurrentValue() throws IOException, InterruptedException {
         return value;
     }
 
     @Override
     public boolean nextKeyValue() throws IOException, InterruptedException {
 
-		Message message = null ;
+        Message message = null;
 
         // we only pull for a specified time. unfinished work will be
         // rescheduled in the next
@@ -198,7 +181,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
 
         while (true) {
             try {
-                if (reader == null || reader.hasNext() == false) {
+                if (reader == null || !reader.hasNext()) {
                     EtlRequest request = split.popRequest();
                     if (request == null) {
                         return false;
@@ -210,8 +193,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
 
                     key.set(request.getTopic(), request.getLeaderId(), request.getPartition(),
                             request.getOffset(), request.getOffset(), 0);
-                    value = new AvroWrapper<Object>(new Object());
-
+                    value = null;
                     System.out.println("\n\ntopic:" + request.getTopic() + " partition:"
                             + request.getPartition() + " beginOffset:" + request.getOffset()
                             + " estimatedLastOffset:" + request.getLastOffset());
@@ -228,23 +210,23 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
                             CamusJob.getKafkaTimeoutValue(mapperContext),
                             CamusJob.getKafkaBufferSize(mapperContext));
 
-                    decoder = (MessageDecoder<byte[], Record>) MessageDecoderFactory.createMessageDecoder(context, request.getTopic());
+                    decoder = MessageDecoderFactory.createMessageDecoder(context, request.getTopic());
                 }
                 int count = 0;
-                while (reader.getNext(key, msgValue , msgKey)) {
+                while (reader.getNext(key, msgValue, msgKey)) {
                     count++;
                     context.progress();
                     mapperContext.getCounter("total", "data-read").increment(msgValue.getLength());
                     mapperContext.getCounter("total", "event-count").increment(1);
                     byte[] bytes = getBytes(msgValue);
-		    byte[] keyBytes = getBytes(msgKey);
-		    // check the checksum of message.
-		    // If message has partiion key, need to construct it with Key for checkSum to match
-		    if(keyBytes.length == 0){
-			message = new Message(bytes);
-		    }else{
-			message = new Message(bytes,keyBytes);
-		    }
+                    byte[] keyBytes = getBytes(msgKey);
+                    // check the checksum of message.
+                    // If message has partition key, need to construct it with Key for checkSum to match
+                    if (keyBytes.length == 0) {
+                        message = new Message(bytes);
+                    } else {
+                        message = new Message(bytes, keyBytes);
+                    }
                     long checksum = key.getChecksum();
                     if (checksum != message.checksum()) {
                         throw new ChecksumException("Invalid message checksum "
@@ -257,16 +239,13 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
                     try {
                         wrapper = getWrappedRecord(key.getTopic(), bytes);
                     } catch (Exception e) {
-                        if(exceptionCount < getMaximumDecoderExceptionsToPrint(context))
-				{
-					mapperContext.write(key, new ExceptionWritable(e));
-					exceptionCount++;
-				} else
-				if(exceptionCount == getMaximumDecoderExceptionsToPrint(context))
-				{
-					exceptionCount = Integer.MAX_VALUE; //Any random value
-					System.out.println("The same exception has occured for more than " + getMaximumDecoderExceptionsToPrint(context) + " records. All further exceptions will not be printed");	
-				}
+                        if (exceptionCount < getMaximumDecoderExceptionsToPrint(context)) {
+                            mapperContext.write(key, new ExceptionWritable(e));
+                            exceptionCount++;
+                        } else if (exceptionCount == getMaximumDecoderExceptionsToPrint(context)) {
+                            exceptionCount = Integer.MAX_VALUE; //Any random value
+                            System.out.println("The same exception has occured for more than " + getMaximumDecoderExceptionsToPrint(context) + " records. All further exceptions will not be printed");
+                        }
                         continue;
                     }
 
@@ -294,9 +273,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
                         System.out.println(key.getTopic() + " begin read at " + time.toString());
                         endTimeStamp = (time.plusHours(this.maxPullHours)).getMillis();
                     } else if (timeStamp > endTimeStamp || System.currentTimeMillis() > maxPullTime) {
-                        if(timeStamp > endTimeStamp)
-                        System.out.println("Kafka Max history hours reached");
-                        if(System.currentTimeMillis() > maxPullTime)
+                        if (timeStamp > endTimeStamp)
+                            System.out.println("Kafka Max history hours reached");
+                        if (System.currentTimeMillis() > maxPullTime)
                             System.out.println("Kafka pull time limit reached");
                         statusMsg += " max read at " + new DateTime(timeStamp).toString();
                         context.setStatus(statusMsg);
@@ -308,7 +287,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
                     }
 
                     long secondTime = System.currentTimeMillis();
-                    value.datum(wrapper.getRecord());
+                    value = wrapper;
                     long decodeTime = ((secondTime - tempTime));
 
                     mapperContext.getCounter("total", "decode-time(ms)").increment(decodeTime);
@@ -345,7 +324,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, AvroWrapper<Object>> {
         }
     }
 
-   public static int getMaximumDecoderExceptionsToPrint(JobContext job) {
-    	return job.getConfiguration().getInt(PRINT_MAX_DECODER_EXCEPTIONS, 10);
+    public static int getMaximumDecoderExceptionsToPrint(JobContext job) {
+        return job.getConfiguration().getInt(PRINT_MAX_DECODER_EXCEPTIONS, 10);
     }
 }


### PR DESCRIPTION
...e RecordWriterProvider interface and specify the implementation by setting the etl.record.writer.provider.class property in your camus properties file, e.g.

etl.record.writer.provider.class=com.jivesoftware.jive.platform.kafka.camus.JSONRecordWriterProvider
