### PR TITLE
LatestSchemaKafkaAvroMessageDecoder : Fixing IndexOutOfBoundsException

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/coders/LatestSchemaKafkaAvroMessageDecoder.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/coders/LatestSchemaKafkaAvroMessageDecoder.java
@@ -31,7 +31,7 @@ public class LatestSchemaKafkaAvroMessageDecoder extends KafkaAvroMessageDecoder
                                     payload, 
                                     //Message.payloadOffset(message.magic()),
                                     Message.MagicOffset(),
-                                    payload.length
+                                    payload.length - Message.MagicOffset()
                             )
                     )
             ));


### PR DESCRIPTION
Fixing `IndexOutOfBoundsException` when instantiating new String with `byte[] payload`.

Calling `new String(payload, 4, payload.length)` causes Java to attempt to read
4 bytes beyond the end of payload, which throws and `IndexOutOfBoundsException`.

I am compiling with the provided kafka 0.8 jar, so I'm pretty sure Message.MagicOffset() is 4.
In Message.scala:

``` scala
  /**
   * The current offset and size for all the fixed-length fields
   */
  val CrcOffset = 0
  val CrcLength = 4
  val MagicOffset = CrcOffset + CrcLength
```

Even so, I'm not sure how this ever worked.  Wouldn't this always cause an exception?
