### PR TITLE
Adding StringRecordWriterProvider.

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/StringRecordWriterProvider.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/StringRecordWriterProvider.java
@@ -19,7 +19,10 @@ import org.apache.log4j.Logger;
  * a String record as bytes to HDFS without any reformatting or compession.
  */
 public class StringRecordWriterProvider implements RecordWriterProvider {
+    public static final String ETL_OUTPUT_RECORD_DELIMITER = "etl.output.record.delimiter";
+    public static final String DEFAULT_RECORD_DELIMITER    = "";
 
+    protected String recordDelimiter = null;
 
     // TODO: Make this configurable somehow.
     // To do this, we'd have to make RecordWriterProvider have an
@@ -35,6 +38,14 @@ public class StringRecordWriterProvider implements RecordWriterProvider {
             String              fileName,
             CamusWrapper        camusWrapper,
             FileOutputCommitter committer) throws IOException, InterruptedException {
+
+        // If recordDelimiter hasn't been initialized, do so now
+        if (recordDelimiter == null) {
+            recordDelimiter = context.getConfiguration().get(
+                ETL_OUTPUT_RECORD_DELIMITER,
+                DEFAULT_RECORD_DELIMITER
+            );
+        }
 
         // Get the filename for this RecordWriter.
         Path path = new Path(
@@ -52,7 +63,8 @@ public class StringRecordWriterProvider implements RecordWriterProvider {
         return new RecordWriter<IEtlKey, CamusWrapper>() {
             @Override
             public void write(IEtlKey ignore, CamusWrapper data) throws IOException {
-                writer.write(((String)data.getRecord()).getBytes());
+                String record = (String)data.getRecord() + recordDelimiter;
+                writer.write(record.getBytes());
             }
 
             @Override


### PR DESCRIPTION
Adding `StringRecordWriterProvider`.

The returned `RecordWriter` will write out the `CamusRecord`'s data as String bytes.
This is useful for writing to HDFS directly what comes out of Kafka, instead of
always having to use Avro.

Any good?  Gimme tips!
