### PR TITLE
Configurable record writer provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Here is an abbreviated list of commonly used parameters.
 * If whitelist has values, only whitelisted topic are pulled.  Nothing on the blacklist is pulled
  * kafka.blacklist.topics=
  * kafka.whitelist.topics=
+* The class to use to write records to HDFS
+ * etl.record.writer.provider.class=com.linkedin.camus.etl.kafka.common.AvroRecordWriterProvider
 
 ### Running Camus
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -131,6 +131,23 @@ public class CamusJob extends Configured implements Tool {
 					props.getProperty(key.toString()));
 		}
 
+                // Check for a configuration option for the record writer
+                // provider and set it in the job context if it exists
+                String recordWriterProviderClassName =
+                    props.getProperty(EtlMultiOutputFormat.ETL_RECORD_WRITER_PROVIDER_CLASS);
+                if (recordWriterProviderClassName != null) {
+                    try {
+                        Class recordWriterProviderClass =
+                            Class.forName(recordWriterProviderClassName);
+                        EtlMultiOutputFormat.setRecordWriterProviderClass(job, recordWriterProviderClass);
+                    }
+                    catch (ClassNotFoundException cnfe) {
+                        log.error("Cannot find class for " +
+                                EtlMultiOutputFormat.ETL_RECORD_WRITER_PROVIDER_CLASS + ": " +
+                                recordWriterProviderClassName);
+                    }
+                }
+
 		FileSystem fs = FileSystem.get(job.getConfiguration());
 
 		String hadoopCacheJarDir = job.getConfiguration().get(


### PR DESCRIPTION
Allows the user to configure the RecordWriterProvider, which is useful if you do not want to write out Avro container files.
