### PR TITLE
Allow passing a list of brokers to Camus. 

### DIFF
--- a/camus-example/src/main/resources/camus.properties
+++ b/camus-example/src/main/resources/camus.properties
@@ -51,9 +51,8 @@ kafka.fetch.buffer.size=
 kafka.fetch.request.correlationid=
 kafka.fetch.request.max.wait=
 kafka.fetch.request.min.bytes=
-# Connection parameters. Usually a VIP
-kafka.host.url=
-kafka.host.port=
+# Connection parameters.
+kafka.brokers=
 kafka.timeout.value=
 
 


### PR DESCRIPTION
This removes the need to place the Kafka brokers behind a loadbalancer. That said, the list is only used for the initial metadata discovery and for sending messages back to Kafka - individual broker failures after starting the job can still fail the job.
