### PR TITLE
AvroMemorySchemaRegistry

### DIFF
--- a/camus-example/src/main/java/com/linkedin/camus/example/schemaregistry/DummySchemaRegistry.java
+++ b/camus-example/src/main/java/com/linkedin/camus/example/schemaregistry/DummySchemaRegistry.java
@@ -5,14 +5,14 @@ import org.apache.hadoop.conf.Configuration;
 
 import com.linkedin.camus.example.records.DummyLog;
 import com.linkedin.camus.example.records.DummyLog2;
-import com.linkedin.camus.schemaregistry.MemorySchemaRegistry;
+import com.linkedin.camus.schemaregistry.AvroMemorySchemaRegistry;
 
 /**
  * This is a little dummy registry that just uses a memory-backed schema
  * registry to store two dummy Avro schemas. You can use this with
  * camus.properties
  */
-public class DummySchemaRegistry extends MemorySchemaRegistry<Schema> {
+public class DummySchemaRegistry extends AvroMemorySchemaRegistry {
 	public DummySchemaRegistry(Configuration conf) {
 		super();
 		super.register("DUMMY_LOG", DummyLog.newBuilder().build().getSchema());

--- a/camus-schema-registry/src/main/java/com/linkedin/camus/schemaregistry/AvroMemorySchemaRegistry.java
+++ b/camus-schema-registry/src/main/java/com/linkedin/camus/schemaregistry/AvroMemorySchemaRegistry.java
@@ -1,0 +1,16 @@
+package com.linkedin.camus.schemaregistry;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaNormalization;
+
+/**
+ * This is an in-memory implementation of a SchemaRegistry that stores
+ * Avro schemas and the Avro fingerprint of the schema as it's id
+ */
+public class AvroMemorySchemaRegistry extends MemorySchemaRegistry<Schema> {
+	
+	@Override
+    protected long generateSchemaId(Schema schema) {
+	    return SchemaNormalization.parsingFingerprint64(schema);
+    }
+}

--- a/camus-schema-registry/src/main/java/com/linkedin/camus/schemaregistry/MemorySchemaRegistry.java
+++ b/camus-schema-registry/src/main/java/com/linkedin/camus/schemaregistry/MemorySchemaRegistry.java
@@ -29,14 +29,18 @@ public class MemorySchemaRegistry<S> implements SchemaRegistry<S> {
 
 	@Override
 	public String register(String topic, S schema) {
-		long id = ids.incrementAndGet();
+		long id = generateSchemaId(schema);
 		MemorySchemaRegistryTuple tuple = new MemorySchemaRegistryTuple(topic,
 				id);
 		schemasById.put(tuple, schema);
 		latest.put(topic, tuple);
 		return Long.toString(id);
 	}
-
+	
+	protected long generateSchemaId(S schema) {
+		return ids.incrementAndGet();
+	}
+	
 	@Override
 	public S getSchemaByID(String topicName, String idStr) {
 		try {


### PR DESCRIPTION
If you like the idea, this is a simple class that uses Avro schema fingerprints to generate schema ids instead of an atomic counter variable. It gets rid of the need to add schemas in the same order across object instantiations and guarantees that clients will get the same id if the same schema is registered more than once.
