### PR TITLE
Added sort to guarantee ordering of executions

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -233,8 +233,7 @@ public class CamusJob extends Configured implements Tool {
 		FileStatus[] executions = fs.listStatus(execHistory);
 		Arrays.sort(executions, new Comparator<FileStatus>() {
 			public int compare(FileStatus f1, FileStatus f2) {
-				return Long.valueOf(f1.getModificationTime())
-						.compareTo(f2.getModificationTime());
+				return f1.getPath().getName().compareTo(f2.getPath().getName());
 			}
 		});
 		


### PR DESCRIPTION
When Camus is deleting old executions and finding the latest, the
ordering of executions was not guaranteed. (i.e. Camus may find a
previous execution that isn't the latest). This has been an issue when
testing Camus using the local file system or under certain Hadoop
distributions. The listing of execution files is now sorted into lexicographical order.
