### PR TITLE
The partitionID is persisted with the messages. In this case, the checks...

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -237,16 +237,15 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
                     byte[] keyBytes = getBytes(msgKey);
                     // check the checksum of message.
                     // If message has partition key, need to construct it with Key for checkSum to match
-                    if (keyBytes.length == 0) {
-                        message = new Message(bytes);
-                    } else {
-                        message = new Message(bytes, keyBytes);
-                    }
+                    Message messageWithKey = new Message(bytes,keyBytes);
+                    Message messageWithoutKey = new Message(bytes);
                     long checksum = key.getChecksum();
-                    if (checksum != message.checksum()) {
-                        throw new ChecksumException("Invalid message checksum "
-                                + message.checksum() + ". Expected " + key.getChecksum(),
-                                key.getOffset());
+                    if (checksum != messageWithKey.checksum() && checksum != messageWithoutKey.checksum()) {
+                    	throw new ChecksumException("Invalid message checksum : MessageWithKey : "
+                              + messageWithKey.checksum() + " MessageWithoutKey checksum : " 
+                    		  + messageWithoutKey.checksum() 
+                    		  + ". Expected " + key.getChecksum(),	
+                    		  key.getOffset());
                     }
 
                     long tempTime = System.currentTimeMillis();


### PR DESCRIPTION
...um with and without the key, both need to be considered.
