### PR TITLE
use elephantbird HadoopCompat to get running on hadoop 2 mr1

### DIFF
--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -67,6 +67,11 @@
 			<artifactId>commons-cli</artifactId>
 			<version>1.2</version>
 		</dependency>
+                <dependency>
+                    <groupId>com.twitter.elephantbird</groupId>
+                    <artifactId>elephant-bird-hadoop-compat</artifactId>
+                    <version>4.4</version>
+                </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -66,6 +66,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 
+import com.twitter.elephantbird.util.HadoopCompat;
+
 public class CamusJob extends Configured implements Tool {
 
 	public static final String ETL_EXECUTION_BASE_PATH = "etl.execution.base.path";
@@ -99,7 +101,7 @@ public class CamusJob extends Configured implements Tool {
 	public CamusJob(Properties props) throws IOException {
 		this(props, org.apache.log4j.Logger.getLogger(CamusJob.class));
 	}
-	
+
 	 public CamusJob(Properties props, Logger log) throws IOException {
 	    this.props = props;
 	    this.log = log;
@@ -124,19 +126,19 @@ public class CamusJob extends Configured implements Tool {
 				(timingMap.get(name) == null ? 0 : timingMap.get(name))
 						+ System.currentTimeMillis());
 	}
-	
+
 	private Job createJob(Properties props) throws IOException {
-	  Job job; 
+	  Job job;
 	  if(getConf() == null)
 	    {
-	      setConf(new Configuration()); 
+	      setConf(new Configuration());
 	    }
-	  
+
 	  populateConf(props, getConf(), log);
-	  
+
 	  job = new Job(getConf());
 	  job.setJarByClass(CamusJob.class);
-	  
+
 	   if(job.getConfiguration().get("camus.job.name") != null)
 	    {
 	      job.setJobName(job.getConfiguration().get("camus.job.name"));
@@ -145,7 +147,7 @@ public class CamusJob extends Configured implements Tool {
 	   {
 	     job.setJobName("Camus Job");
 	   }
-	   
+
 	  return job;
 	}
 
@@ -235,7 +237,7 @@ public class CamusJob extends Configured implements Tool {
 				return f1.getPath().getName().compareTo(f2.getPath().getName());
 			}
 		});
-		
+
 		// removes oldest directory until we get under required % of count
 		// quota. Won't delete the most recent directory.
 		for (int i = 0; i < executions.length - 1 && limit < currentCount; i++) {
@@ -271,7 +273,7 @@ public class CamusJob extends Configured implements Tool {
 				+ newExecutionOutput.toString());
 
 		EtlInputFormat.setLogger(log);
-		
+
 		job.setInputFormatClass(EtlInputFormat.class);
 		job.setOutputFormatClass(EtlMultiOutputFormat.class);
 		job.setNumReduceTasks(0);
@@ -436,7 +438,7 @@ public class CamusJob extends Configured implements Tool {
 	/**
 	 * Creates a diagnostic report mostly focused on timing breakdowns. Useful
 	 * for determining where to optimize.
-	 * 
+	 *
 	 * @param job
 	 * @param timingMap
 	 * @throws IOException
@@ -610,58 +612,58 @@ public class CamusJob extends Configured implements Tool {
 	}
 
 	// Temporarily adding all Kafka parameters here
-	public static boolean getPostTrackingCountsToKafka(Job job) {
-		return job.getConfiguration().getBoolean(POST_TRACKING_COUNTS_TO_KAFKA,
+	public static boolean getPostTrackingCountsToKafka(JobContext job) {
+		return HadoopCompat.getConfiguration(job).getBoolean(POST_TRACKING_COUNTS_TO_KAFKA,
 				true);
 	}
 
-	public static int getKafkaFetchRequestMinBytes(JobContext context) {
-		return context.getConfiguration().getInt(KAFKA_FETCH_REQUEST_MIN_BYTES,
+	public static int getKafkaFetchRequestMinBytes(JobContext job) {
+		return HadoopCompat.getConfiguration(job).getInt(KAFKA_FETCH_REQUEST_MIN_BYTES,
 				1024);
 	}
 
 	public static int getKafkaFetchRequestMaxWait(JobContext job) {
-		return job.getConfiguration()
+		return HadoopCompat.getConfiguration(job)
 				.getInt(KAFKA_FETCH_REQUEST_MAX_WAIT, 1000);
 	}
 
 	public static String getKafkaBrokers(JobContext job) {
-		String brokers = job.getConfiguration().get(KAFKA_BROKERS);
+		String brokers = HadoopCompat.getConfiguration(job).get(KAFKA_BROKERS);
 		if (brokers == null) {
-			brokers = job.getConfiguration().get(KAFKA_HOST_URL);
+			brokers = HadoopCompat.getConfiguration(job).get(KAFKA_HOST_URL);
 			if (brokers != null) {
-				log.warn("The configuration properties " + KAFKA_HOST_URL + " and " + 
+				log.warn("The configuration properties " + KAFKA_HOST_URL + " and " +
 					KAFKA_HOST_PORT + " are deprecated. Please switch to using " + KAFKA_BROKERS);
-				return brokers + ":" + job.getConfiguration().getInt(KAFKA_HOST_PORT, 10251);
+				return brokers + ":" + HadoopCompat.getConfiguration(job).getInt(KAFKA_HOST_PORT, 10251);
 			}
 		}
 		return brokers;
 	}
 
 	public static int getKafkaFetchRequestCorrelationId(JobContext job) {
-		return job.getConfiguration().getInt(
+		return HadoopCompat.getConfiguration(job).getInt(
 				KAFKA_FETCH_REQUEST_CORRELATION_ID, -1);
 	}
 
 	public static String getKafkaClientName(JobContext job) {
-		return job.getConfiguration().get(KAFKA_CLIENT_NAME);
+		return HadoopCompat.getConfiguration(job).get(KAFKA_CLIENT_NAME);
 	}
 
 	public static String getKafkaFetchRequestBufferSize(JobContext job) {
-		return job.getConfiguration().get(KAFKA_FETCH_BUFFER_SIZE);
+		return HadoopCompat.getConfiguration(job).get(KAFKA_FETCH_BUFFER_SIZE);
 	}
 
 	public static int getKafkaTimeoutValue(JobContext job) {
-		int timeOut = job.getConfiguration().getInt(KAFKA_TIMEOUT_VALUE, 30000);
+		int timeOut = HadoopCompat.getConfiguration(job).getInt(KAFKA_TIMEOUT_VALUE, 30000);
 		return timeOut;
 	}
 
 	public static int getKafkaBufferSize(JobContext job) {
-		return job.getConfiguration().getInt(KAFKA_FETCH_BUFFER_SIZE,
+		return HadoopCompat.getConfiguration(job).getInt(KAFKA_FETCH_BUFFER_SIZE,
 				1024 * 1024);
 	}
 
 	public static boolean getLog4jConfigure(JobContext job) {
-		return job.getConfiguration().getBoolean(LOG4J_CONFIGURATION, false);
+		return HadoopCompat.getConfiguration(job).getBoolean(LOG4J_CONFIGURATION, false);
 	}
 }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/coders/MessageDecoderFactory.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/coders/MessageDecoderFactory.java
@@ -9,24 +9,26 @@ import com.linkedin.camus.coders.MessageDecoder;
 import com.linkedin.camus.coders.MessageDecoderException;
 import com.linkedin.camus.etl.kafka.mapred.EtlInputFormat;
 
+import com.twitter.elephantbird.util.HadoopCompat;
+
 public class MessageDecoderFactory {
-    
+
     public static MessageDecoder<?,?> createMessageDecoder(JobContext context, String topicName){
         MessageDecoder<?,?> decoder;
         try {
             decoder = (MessageDecoder<?,?>) EtlInputFormat.getMessageDecoderClass(context).newInstance();
-            
+
             Properties props = new Properties();
-            for (Entry<String, String> entry : context.getConfiguration()){
+            for (Entry<String, String> entry : HadoopCompat.getConfiguration(context)) {
                 props.put(entry.getKey(), entry.getValue());
             }
-            
+
             decoder.init(props, topicName);
-            
+
             return decoder;
         } catch (Exception e) {
             throw new MessageDecoderException(e);
-        }    
+        }
     }
 
 }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlRequest.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlRequest.java
@@ -23,15 +23,15 @@ import com.linkedin.camus.etl.kafka.CamusJob;
 
 /**
  * A class that represents the kafka pull request.
- * 
+ *
  * The class is a container for topic, leaderId, partition, uri and offset. It is
  * used in reading and writing the sequence files used for the extraction job.
- * 
+ *
  * @author Richard Park
  */
 public class EtlRequest implements Writable {
-	
-	private static Logger log = Logger.getLogger(EtlRequest.class);
+
+    private static Logger log = Logger.getLogger(EtlRequest.class);
     private JobContext context = null;
     private static final long DEFAULT_OFFSET = 0;
 
@@ -43,7 +43,7 @@ public class EtlRequest implements Writable {
     private long offset = DEFAULT_OFFSET;
     private long latestOffset = -1;
     private long earliestOffset = -2;
-    
+
     public EtlRequest() {
     }
 
@@ -60,16 +60,16 @@ public class EtlRequest implements Writable {
     public void setLatestOffset(long latestOffset) {
 		this.latestOffset = latestOffset;
 	}
-    
+
     public void setEarliestOffset(long earliestOffset) {
 		this.earliestOffset = earliestOffset;
 	}
-    
+
     /**
      * Constructor for a KafkaETLRequest with the uri set to null and offset set
      * to -1. Both of these attributes can be set later. These attributes are
      * sufficient to ensure uniqueness.
-     * 
+     *
      * @param topic
      *            The topic name
      * @param leaderId
@@ -83,7 +83,7 @@ public class EtlRequest implements Writable {
 
     /**
      * Constructor for the KafkaETLRequest with the offset to -1.
-     * 
+     *
      * @param topic
      *            The topic name
      * @param leaderId
@@ -100,7 +100,7 @@ public class EtlRequest implements Writable {
     /**
      * Constructor for the full kafka pull job. Neither the brokerUri nor offset
      * are used to ensure uniqueness.
-     * 
+     *
      * @param topic
      *            The topic name
      * @param leaderId
@@ -123,7 +123,7 @@ public class EtlRequest implements Writable {
 
     /**
      * Sets the starting offset used by the kafka pull mapper.
-     * 
+     *
      * @param offset
      */
     public void setOffset(long offset) {
@@ -132,7 +132,7 @@ public class EtlRequest implements Writable {
 
     /**
      * Sets the broker uri for this request
-     * 
+     *
      * @param uri
      */
     public void setURI(URI uri) {
@@ -141,7 +141,7 @@ public class EtlRequest implements Writable {
 
     /**
      * Retrieve the broker node id.
-     * 
+     *
      * @return
      */
     public String getLeaderId() {
@@ -150,7 +150,7 @@ public class EtlRequest implements Writable {
 
     /**
      * Retrieve the topic
-     * 
+     *
      * @return
      */
     public String getTopic() {
@@ -159,7 +159,7 @@ public class EtlRequest implements Writable {
 
     /**
      * Retrieves the uri if set. The default is null.
-     * 
+     *
      * @return
      */
     public URI getURI() {
@@ -168,7 +168,7 @@ public class EtlRequest implements Writable {
 
     /**
      * Retrieves the partition number
-     * 
+     *
      * @return
      */
     public int getPartition() {
@@ -177,22 +177,22 @@ public class EtlRequest implements Writable {
 
     /**
      * Retrieves the offset
-     * 
+     *
      * @return
      */
     public long getOffset() {
         return this.offset;
     }
 
-    
+
     public void setLeaderId(String leaderId) {
         this.leaderId = leaderId;
     }
-    
+
     /**
      * Returns true if the offset is valid (>= to earliest offset && <= to last
      * offset)
-     * 
+     *
      * @return
      */
     public boolean isValidOffset() {
@@ -248,7 +248,7 @@ public class EtlRequest implements Writable {
         if (this.latestOffset == -1 && uri != null)
             return getLastOffset(kafka.api.OffsetRequest.LatestTime());
         else
-        {           
+        {
         	return this.latestOffset;
         }
     }
@@ -279,7 +279,7 @@ public class EtlRequest implements Writable {
     /**
      * Estimates the request size in bytes by connecting to the broker and
      * querying for the offset that bets matches the endTime.
-     * 
+     *
      * @param endTime
      *            The time in millisec
      */

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -46,6 +46,8 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.log4j.Logger;
 
+import com.twitter.elephantbird.util.HadoopCompat;
+
 /**
  * Input format for a Kafka pull job.
  */
@@ -68,13 +70,13 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 	public static final String ETL_AUDIT_IGNORE_SERVICE_TOPIC_LIST = "etl.audit.ignore.service.topic.list";
 
 	private static Logger log = null;
-	
+
 	public EtlInputFormat()
   {
 	  if (log == null)
 	    log = Logger.getLogger(getClass());
   }
-	
+
 	public static void setLogger(Logger log){
 	  EtlInputFormat.log = log;
 	}
@@ -88,7 +90,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 
 	/**
 	 * Gets the metadata from Kafka
-	 * 
+	 *
 	 * @param context
 	 * @return
 	 */
@@ -126,7 +128,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 		CamusJob.stopTiming("kafkaSetupTime");
 		return topicMetadataList;
 	}
- 
+
 	private SimpleConsumer createConsumer(JobContext context, String broker) {
 		if (!broker.matches(".+:\\d+"))
 			throw new InvalidParameterException("The kakfa broker " + broker + " must follow address:port pattern");
@@ -142,7 +144,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 
 	/**
 	 * Gets the latest offsets and create the requests as needed
-	 * 
+	 *
 	 * @param context
 	 * @param offsetRequestInfo
 	 * @return
@@ -397,7 +399,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 
 	private List<InputSplit> allocateWork(List<EtlRequest> requests,
 			JobContext context) throws IOException {
-		int numTasks = context.getConfiguration()
+		int numTasks = HadoopCompat.getConfiguration(context)
 				.getInt("mapred.map.tasks", 30);
 		// Reverse sort by size
 		Collections.sort(requests, new Comparator<EtlRequest>() {
@@ -451,7 +453,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 
 	private void writePrevious(Collection<EtlKey> missedKeys, JobContext context)
 			throws IOException {
-		FileSystem fs = FileSystem.get(context.getConfiguration());
+		FileSystem fs = FileSystem.get(HadoopCompat.getConfiguration(context));
 		Path output = FileOutputFormat.getOutputPath(context);
 
 		if (fs.exists(output)) {
@@ -461,7 +463,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 		output = new Path(output, EtlMultiOutputFormat.OFFSET_PREFIX
 				+ "-previous");
 		SequenceFile.Writer writer = SequenceFile.createWriter(fs,
-				context.getConfiguration(), output, EtlKey.class,
+				HadoopCompat.getConfiguration(context), output, EtlKey.class,
 				NullWritable.class);
 
 		for (EtlKey key : missedKeys) {
@@ -473,7 +475,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 
 	private void writeRequests(List<EtlRequest> requests, JobContext context)
 			throws IOException {
-		FileSystem fs = FileSystem.get(context.getConfiguration());
+		FileSystem fs = FileSystem.get(HadoopCompat.getConfiguration(context));
 		Path output = FileOutputFormat.getOutputPath(context);
 
 		if (fs.exists(output)) {
@@ -482,7 +484,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 
 		output = new Path(output, EtlMultiOutputFormat.REQUESTS_FILE);
 		SequenceFile.Writer writer = SequenceFile.createWriter(fs,
-				context.getConfiguration(), output, EtlRequest.class,
+				HadoopCompat.getConfiguration(context), output, EtlRequest.class,
 				NullWritable.class);
 
 		for (EtlRequest r : requests) {
@@ -495,11 +497,11 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 			JobContext context) throws IOException {
 		Map<EtlRequest, EtlKey> offsetKeysMap = new HashMap<EtlRequest, EtlKey>();
 		for (Path input : inputs) {
-			FileSystem fs = input.getFileSystem(context.getConfiguration());
+			FileSystem fs = input.getFileSystem(HadoopCompat.getConfiguration(context));
 			for (FileStatus f : fs.listStatus(input, new OffsetFileFilter())) {
 				log.info("previous offset file:" + f.getPath().toString());
 				SequenceFile.Reader reader = new SequenceFile.Reader(fs,
-						f.getPath(), context.getConfiguration());
+						f.getPath(), HadoopCompat.getConfiguration(context));
 				EtlKey key = new EtlKey();
 				while (reader.next(key, NullWritable.get())) {
 					EtlRequest request = new EtlRequest(context,
@@ -523,109 +525,109 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 	}
 
 	public static void setMoveToLatestTopics(JobContext job, String val) {
-		job.getConfiguration().set(KAFKA_MOVE_TO_LAST_OFFSET_LIST, val);
+		HadoopCompat.getConfiguration(job).set(KAFKA_MOVE_TO_LAST_OFFSET_LIST, val);
 	}
 
 	public static String[] getMoveToLatestTopics(JobContext job) {
-		return job.getConfiguration()
+		return HadoopCompat.getConfiguration(job)
 				.getStrings(KAFKA_MOVE_TO_LAST_OFFSET_LIST);
 	}
 
 	public static void setKafkaClientBufferSize(JobContext job, int val) {
-		job.getConfiguration().setInt(KAFKA_CLIENT_BUFFER_SIZE, val);
+		HadoopCompat.getConfiguration(job).setInt(KAFKA_CLIENT_BUFFER_SIZE, val);
 	}
 
 	public static int getKafkaClientBufferSize(JobContext job) {
-		return job.getConfiguration().getInt(KAFKA_CLIENT_BUFFER_SIZE,
+		return HadoopCompat.getConfiguration(job).getInt(KAFKA_CLIENT_BUFFER_SIZE,
 				2 * 1024 * 1024);
 	}
 
 	public static void setKafkaClientTimeout(JobContext job, int val) {
-		job.getConfiguration().setInt(KAFKA_CLIENT_SO_TIMEOUT, val);
+		HadoopCompat.getConfiguration(job).setInt(KAFKA_CLIENT_SO_TIMEOUT, val);
 	}
 
 	public static int getKafkaClientTimeout(JobContext job) {
-		return job.getConfiguration().getInt(KAFKA_CLIENT_SO_TIMEOUT, 60000);
+		return HadoopCompat.getConfiguration(job).getInt(KAFKA_CLIENT_SO_TIMEOUT, 60000);
 	}
 
 	public static void setKafkaMaxPullHrs(JobContext job, int val) {
-		job.getConfiguration().setInt(KAFKA_MAX_PULL_HRS, val);
+		HadoopCompat.getConfiguration(job).setInt(KAFKA_MAX_PULL_HRS, val);
 	}
 
 	public static int getKafkaMaxPullHrs(JobContext job) {
-		return job.getConfiguration().getInt(KAFKA_MAX_PULL_HRS, -1);
+		return HadoopCompat.getConfiguration(job).getInt(KAFKA_MAX_PULL_HRS, -1);
 	}
 
 	public static void setKafkaMaxPullMinutesPerTask(JobContext job, int val) {
-		job.getConfiguration().setInt(KAFKA_MAX_PULL_MINUTES_PER_TASK, val);
+		HadoopCompat.getConfiguration(job).setInt(KAFKA_MAX_PULL_MINUTES_PER_TASK, val);
 	}
 
 	public static int getKafkaMaxPullMinutesPerTask(JobContext job) {
-		return job.getConfiguration().getInt(KAFKA_MAX_PULL_MINUTES_PER_TASK,
+		return HadoopCompat.getConfiguration(job).getInt(KAFKA_MAX_PULL_MINUTES_PER_TASK,
 				-1);
 	}
 
 	public static void setKafkaMaxHistoricalDays(JobContext job, int val) {
-		job.getConfiguration().setInt(KAFKA_MAX_HISTORICAL_DAYS, val);
+		HadoopCompat.getConfiguration(job).setInt(KAFKA_MAX_HISTORICAL_DAYS, val);
 	}
 
 	public static int getKafkaMaxHistoricalDays(JobContext job) {
-		return job.getConfiguration().getInt(KAFKA_MAX_HISTORICAL_DAYS, -1);
+		return HadoopCompat.getConfiguration(job).getInt(KAFKA_MAX_HISTORICAL_DAYS, -1);
 	}
 
 	public static void setKafkaBlacklistTopic(JobContext job, String val) {
-		job.getConfiguration().set(KAFKA_BLACKLIST_TOPIC, val);
+		HadoopCompat.getConfiguration(job).set(KAFKA_BLACKLIST_TOPIC, val);
 	}
 
 	public static String[] getKafkaBlacklistTopic(JobContext job) {
-		if (job.getConfiguration().get(KAFKA_BLACKLIST_TOPIC) != null
-				&& !job.getConfiguration().get(KAFKA_BLACKLIST_TOPIC).isEmpty()) {
-			return job.getConfiguration().getStrings(KAFKA_BLACKLIST_TOPIC);
+		if (HadoopCompat.getConfiguration(job).get(KAFKA_BLACKLIST_TOPIC) != null
+				&& !HadoopCompat.getConfiguration(job).get(KAFKA_BLACKLIST_TOPIC).isEmpty()) {
+			return HadoopCompat.getConfiguration(job).getStrings(KAFKA_BLACKLIST_TOPIC);
 		} else {
 			return new String[] {};
 		}
 	}
 
 	public static void setKafkaWhitelistTopic(JobContext job, String val) {
-		job.getConfiguration().set(KAFKA_WHITELIST_TOPIC, val);
+		HadoopCompat.getConfiguration(job).set(KAFKA_WHITELIST_TOPIC, val);
 	}
 
 	public static String[] getKafkaWhitelistTopic(JobContext job) {
-		if (job.getConfiguration().get(KAFKA_WHITELIST_TOPIC) != null
-				&& !job.getConfiguration().get(KAFKA_WHITELIST_TOPIC).isEmpty()) {
-			return job.getConfiguration().getStrings(KAFKA_WHITELIST_TOPIC);
+		if (HadoopCompat.getConfiguration(job).get(KAFKA_WHITELIST_TOPIC) != null
+				&& !HadoopCompat.getConfiguration(job).get(KAFKA_WHITELIST_TOPIC).isEmpty()) {
+			return HadoopCompat.getConfiguration(job).getStrings(KAFKA_WHITELIST_TOPIC);
 		} else {
 			return new String[] {};
 		}
 	}
 
 	public static void setEtlIgnoreSchemaErrors(JobContext job, boolean val) {
-		job.getConfiguration().setBoolean(ETL_IGNORE_SCHEMA_ERRORS, val);
+		HadoopCompat.getConfiguration(job).setBoolean(ETL_IGNORE_SCHEMA_ERRORS, val);
 	}
 
 	public static boolean getEtlIgnoreSchemaErrors(JobContext job) {
-		return job.getConfiguration().getBoolean(ETL_IGNORE_SCHEMA_ERRORS,
+		return HadoopCompat.getConfiguration(job).getBoolean(ETL_IGNORE_SCHEMA_ERRORS,
 				false);
 	}
 
 	public static void setEtlAuditIgnoreServiceTopicList(JobContext job,
 			String topics) {
-		job.getConfiguration().set(ETL_AUDIT_IGNORE_SERVICE_TOPIC_LIST, topics);
+		HadoopCompat.getConfiguration(job).set(ETL_AUDIT_IGNORE_SERVICE_TOPIC_LIST, topics);
 	}
 
 	public static String[] getEtlAuditIgnoreServiceTopicList(JobContext job) {
-		return job.getConfiguration().getStrings(
+		return HadoopCompat.getConfiguration(job).getStrings(
 				ETL_AUDIT_IGNORE_SERVICE_TOPIC_LIST, "");
 	}
 
 	public static void setMessageDecoderClass(JobContext job,
 			Class<MessageDecoder> cls) {
-		job.getConfiguration().setClass(CAMUS_MESSAGE_DECODER_CLASS, cls,
+		HadoopCompat.getConfiguration(job).setClass(CAMUS_MESSAGE_DECODER_CLASS, cls,
 				MessageDecoder.class);
 	}
 
 	public static Class<MessageDecoder> getMessageDecoderClass(JobContext job) {
-		return (Class<MessageDecoder>) job.getConfiguration().getClass(
+		return (Class<MessageDecoder>) HadoopCompat.getConfiguration(job).getClass(
 				CAMUS_MESSAGE_DECODER_CLASS, KafkaAvroMessageDecoder.class);
 	}
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputFormat.java
@@ -23,6 +23,8 @@ import com.linkedin.camus.etl.kafka.common.AvroRecordWriterProvider;
 import com.linkedin.camus.etl.kafka.common.DateUtils;
 import com.linkedin.camus.etl.kafka.common.EtlKey;
 
+import com.twitter.elephantbird.util.HadoopCompat;
+
 /**
  * MultipleAvroOutputFormat.
  *
@@ -75,20 +77,20 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
     }
 
     public static void setRecordWriterProviderClass(JobContext job, Class<RecordWriterProvider> recordWriterProviderClass) {
-        job.getConfiguration().setClass(ETL_RECORD_WRITER_PROVIDER_CLASS, recordWriterProviderClass, RecordWriterProvider.class);
+        HadoopCompat.getConfiguration(job).setClass(ETL_RECORD_WRITER_PROVIDER_CLASS, recordWriterProviderClass, RecordWriterProvider.class);
     }
 
     public static Class<RecordWriterProvider> getRecordWriterProviderClass(
             JobContext job) {
-        return (Class<RecordWriterProvider>) job.getConfiguration()
+        return (Class<RecordWriterProvider>) HadoopCompat.getConfiguration(job)
                 .getClass(ETL_RECORD_WRITER_PROVIDER_CLASS,
                         AvroRecordWriterProvider.class);
     }
-    
+
     public static RecordWriterProvider getRecordWriterProvider(JobContext job) {
         try
         {
-          return (RecordWriterProvider) job.getConfiguration()
+          return (RecordWriterProvider) HadoopCompat.getConfiguration(job)
                    .getClass(ETL_RECORD_WRITER_PROVIDER_CLASS,
                            AvroRecordWriterProvider.class).newInstance();
         }
@@ -99,101 +101,101 @@ public class EtlMultiOutputFormat extends FileOutputFormat<EtlKey, Object> {
     }
 
     public static void setDefaultTimeZone(JobContext job, String tz) {
-        job.getConfiguration().set(ETL_DEFAULT_TIMEZONE, tz);
+        HadoopCompat.getConfiguration(job).set(ETL_DEFAULT_TIMEZONE, tz);
     }
 
     public static String getDefaultTimeZone(JobContext job) {
-        return job.getConfiguration().get(ETL_DEFAULT_TIMEZONE, "America/Los_Angeles");
+        return HadoopCompat.getConfiguration(job).get(ETL_DEFAULT_TIMEZONE, "America/Los_Angeles");
     }
 
     public static void setDestinationPath(JobContext job, Path dest) {
-        job.getConfiguration().set(ETL_DESTINATION_PATH, dest.toString());
+        HadoopCompat.getConfiguration(job).set(ETL_DESTINATION_PATH, dest.toString());
     }
 
     public static Path getDestinationPath(JobContext job) {
-        return new Path(job.getConfiguration().get(ETL_DESTINATION_PATH));
+        return new Path(HadoopCompat.getConfiguration(job).get(ETL_DESTINATION_PATH));
     }
 
     public static void setDestPathTopicSubDir(JobContext job, String subPath) {
-        job.getConfiguration().set(ETL_DESTINATION_PATH_TOPIC_SUBDIRECTORY, subPath);
+        HadoopCompat.getConfiguration(job).set(ETL_DESTINATION_PATH_TOPIC_SUBDIRECTORY, subPath);
     }
 
     public static Path getDestPathTopicSubDir(JobContext job) {
-        return new Path(job.getConfiguration().get(ETL_DESTINATION_PATH_TOPIC_SUBDIRECTORY, "hourly"));
+        return new Path(HadoopCompat.getConfiguration(job).get(ETL_DESTINATION_PATH_TOPIC_SUBDIRECTORY, "hourly"));
     }
 
     public static void setMonitorTimeGranularityMins(JobContext job, int mins) {
-        job.getConfiguration().setInt(KAFKA_MONITOR_TIME_GRANULARITY_MS, mins);
+        HadoopCompat.getConfiguration(job).setInt(KAFKA_MONITOR_TIME_GRANULARITY_MS, mins);
     }
 
     public static int getMonitorTimeGranularityMins(JobContext job) {
-        return job.getConfiguration().getInt(KAFKA_MONITOR_TIME_GRANULARITY_MS, 10);
+        return HadoopCompat.getConfiguration(job).getInt(KAFKA_MONITOR_TIME_GRANULARITY_MS, 10);
     }
 
     public static long getMonitorTimeGranularityMs(JobContext job) {
-      return job.getConfiguration().getInt(KAFKA_MONITOR_TIME_GRANULARITY_MS, 10) * 60000L;
+      return HadoopCompat.getConfiguration(job).getInt(KAFKA_MONITOR_TIME_GRANULARITY_MS, 10) * 60000L;
     }
-    
+
     public static void setEtlAvroWriterSyncInterval(JobContext job, int val) {
-        job.getConfiguration().setInt(ETL_AVRO_WRITER_SYNC_INTERVAL, val);
+        HadoopCompat.getConfiguration(job).setInt(ETL_AVRO_WRITER_SYNC_INTERVAL, val);
     }
 
     public static int getEtlAvroWriterSyncInterval(JobContext job) {
-        return job.getConfiguration().getInt(ETL_AVRO_WRITER_SYNC_INTERVAL, 16000);
+        return HadoopCompat.getConfiguration(job).getInt(ETL_AVRO_WRITER_SYNC_INTERVAL, 16000);
     }
 
     public static void setEtlDeflateLevel(JobContext job, int val) {
-        job.getConfiguration().setInt(ETL_DEFLATE_LEVEL, val);
+        HadoopCompat.getConfiguration(job).setInt(ETL_DEFLATE_LEVEL, val);
     }
 
     public static void setEtlOutputCodec(JobContext job, String codec) {
-        job.getConfiguration().set(ETL_OUTPUT_CODEC, codec);
+        HadoopCompat.getConfiguration(job).set(ETL_OUTPUT_CODEC, codec);
     }
 
     public static String getEtlOutputCodec(JobContext job) {
-        return job.getConfiguration().get(ETL_OUTPUT_CODEC, ETL_DEFAULT_OUTPUT_CODEC);
+        return HadoopCompat.getConfiguration(job).get(ETL_OUTPUT_CODEC, ETL_DEFAULT_OUTPUT_CODEC);
 
     }
     public static int getEtlDeflateLevel(JobContext job) {
-        return job.getConfiguration().getInt(ETL_DEFLATE_LEVEL, 6);
+        return HadoopCompat.getConfiguration(job).getInt(ETL_DEFLATE_LEVEL, 6);
     }
 
     public static int getEtlOutputFileTimePartitionMins(JobContext job) {
-        return job.getConfiguration().getInt(ETL_OUTPUT_FILE_TIME_PARTITION_MINS, 60);
+        return HadoopCompat.getConfiguration(job).getInt(ETL_OUTPUT_FILE_TIME_PARTITION_MINS, 60);
     }
 
     public static void setEtlOutputFileTimePartitionMins(JobContext job, int val) {
-        job.getConfiguration().setInt(ETL_OUTPUT_FILE_TIME_PARTITION_MINS, val);
+        HadoopCompat.getConfiguration(job).setInt(ETL_OUTPUT_FILE_TIME_PARTITION_MINS, val);
     }
 
     public static boolean isRunMoveData(JobContext job) {
-        return job.getConfiguration().getBoolean(ETL_RUN_MOVE_DATA, true);
+        return HadoopCompat.getConfiguration(job).getBoolean(ETL_RUN_MOVE_DATA, true);
     }
 
     public static void setRunMoveData(JobContext job, boolean value) {
-        job.getConfiguration().setBoolean(ETL_RUN_MOVE_DATA, value);
+        HadoopCompat.getConfiguration(job).setBoolean(ETL_RUN_MOVE_DATA, value);
     }
 
     public static boolean isRunTrackingPost(JobContext job) {
-        return job.getConfiguration().getBoolean(ETL_RUN_TRACKING_POST, false);
+        return HadoopCompat.getConfiguration(job).getBoolean(ETL_RUN_TRACKING_POST, false);
     }
 
     public static void setRunTrackingPost(JobContext job, boolean value) {
-        job.getConfiguration().setBoolean(ETL_RUN_TRACKING_POST, value);
+        HadoopCompat.getConfiguration(job).setBoolean(ETL_RUN_TRACKING_POST, value);
     }
 
     public static String getWorkingFileName(JobContext context, EtlKey key) throws IOException {
         Partitioner partitioner = getPartitioner(context, key.getTopic());
         return "data." + key.getTopic().replaceAll("\\.", "_") + "." + key.getLeaderId() + "." + key.getPartition() + "." + partitioner.encodePartition(context, key);
     }
-    
+
     public static void setDefaultPartitioner(JobContext job, Class<?> cls) {
-      job.getConfiguration().setClass(ETL_DEFAULT_PARTITIONER_CLASS, cls, Partitioner.class);
+      HadoopCompat.getConfiguration(job).setClass(ETL_DEFAULT_PARTITIONER_CLASS, cls, Partitioner.class);
     }
-    
+
     public static Partitioner getDefaultPartitioner(JobContext job) {
-        return ReflectionUtils.newInstance(job.getConfiguration().getClass(ETL_DEFAULT_PARTITIONER_CLASS, DefaultPartitioner.class, Partitioner.class), job.getConfiguration());
-    }    
+        return ReflectionUtils.newInstance(HadoopCompat.getConfiguration(job).getClass(ETL_DEFAULT_PARTITIONER_CLASS, DefaultPartitioner.class, Partitioner.class), HadoopCompat.getConfiguration(job));
+    }
 
     public static Partitioner getPartitioner(JobContext job, String topicName) throws IOException {
         String customPartitionerProperty = ETL_DEFAULT_PARTITIONER_CLASS + "." + topicName;

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 
+import com.twitter.elephantbird.util.HadoopCompat;
+
 public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     private static final String PRINT_MAX_DECODER_EXCEPTIONS = "max.decoder.exceptions.to.print";
     private static final String DEFAULT_SERVER = "server";
@@ -102,7 +104,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
         } else {
             beginTimeStamp = 0;
         }
-        
+
         ignoreServerServiceList = new HashSet<String>();
         for(String ignoreServerServiceTopic : EtlInputFormat.getEtlAuditIgnoreServiceTopicList(context))
         {
@@ -242,9 +244,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
                     long checksum = key.getChecksum();
                     if (checksum != messageWithKey.checksum() && checksum != messageWithoutKey.checksum()) {
                     	throw new ChecksumException("Invalid message checksum : MessageWithKey : "
-                              + messageWithKey.checksum() + " MessageWithoutKey checksum : " 
-                    		  + messageWithoutKey.checksum() 
-                    		  + ". Expected " + key.getChecksum(),	
+                              + messageWithKey.checksum() + " MessageWithoutKey checksum : "
+                    		  + messageWithoutKey.checksum()
+                    		  + ". Expected " + key.getChecksum(),
                     		  key.getOffset());
                     }
 
@@ -338,7 +340,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
             }
         }
     }
-    
+
     public void setServerService()
     {
     	if(ignoreServerServiceList.contains(key.getTopic()) || ignoreServerServiceList.contains("all"))
@@ -349,6 +351,6 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     }
 
     public static int getMaximumDecoderExceptionsToPrint(JobContext job) {
-        return job.getConfiguration().getInt(PRINT_MAX_DECODER_EXCEPTIONS, 10);
+        return HadoopCompat.getConfiguration(job).getInt(PRINT_MAX_DECODER_EXCEPTIONS, 10);
     }
 }


### PR DESCRIPTION
This adds support for hadoop 2 while maintaining support for 1.x

One thing to note though: It breaks some of the example configs that do things like this:
```
kafka.fetch.buffer.size=
```

when a key that is expected to be parsed as an integer is uncommented in the properties file but not set, hadoop 2 will set this as empty string, where hadoop 1.x set it as null. hadoop 2 will through an exception when it tries to parse the empty string as an int. 

leaving keys intented to be set using default as commented out works in both cases (and I think is more idiomatic in general).

```
# kafka.fetch.buffer.size=
``` 