### PR TITLE
using midnight in same timezone as rest of code in CamusSweeperDatePartionerPlanner

### DIFF
--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperDatePartitionPlanner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperDatePartitionPlanner.java
@@ -33,8 +33,7 @@ public class CamusSweeperDatePartitionPlanner extends CamusSweeperPlanner
     int daysAgo = Integer.parseInt(props.getProperty("days.ago", "0"));
     int numDays = Integer.parseInt(props.getProperty("num.days", "15"));
 
-    DateTime time = new DateTime();
-    DateTime midnight = new DateTime(time.getYear(), time.getMonthOfYear(), time.getDayOfMonth(), 0, 0, 0, 0);
+    DateTime midnight = dUtils.getMidnight();
     DateTime startDate = midnight.minusDays(daysAgo);
 
     List<Properties> jobPropsList = new ArrayList<Properties>();


### PR DESCRIPTION
Previously, midnight was calculated using the default Joda timezone,
while other parts of the code used camus.timezone.default
