### PR TITLE
Fixed quota override contains logic

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -230,7 +230,7 @@ public class CamusJob extends Configured implements Tool {
 				.getFloat(ETL_EXECUTION_HISTORY_MAX_OF_QUOTA, (float) .5));
 		limit = limit == 0 ? 50000 : limit;
 		
-		if (props.contains(ETL_BASEDIR_QUOTA_OVERIDE)){
+		if (props.containsKey(ETL_BASEDIR_QUOTA_OVERIDE)){
 		  limit = Long.valueOf(props.getProperty(ETL_BASEDIR_QUOTA_OVERIDE));
 		}
 


### PR DESCRIPTION
We used the wrong method here. [contains](http://docs.oracle.com/javase/7/docs/api/java/util/Hashtable.html#contains%28java.lang.Object%29) checks if the value exists in the properties.
