### PR TITLE
Add support for ISO datetime

### DIFF
--- a/camus-kafka-coders/pom.xml
+++ b/camus-kafka-coders/pom.xml
@@ -26,11 +26,16 @@
 			<artifactId>gson</artifactId>
 			<scope>compile</scope>
 		</dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
+	    	<dependency>
+		        <groupId>junit</groupId>
+	        	<artifactId>junit</artifactId>
+	        	<scope>test</scope>
+    		</dependency>
+	    	<dependency>
+	    		<groupId>joda-time</groupId>
+	     		<artifactId>joda-time</artifactId>
+	     		<version>2.2</version>
+	    	</dependency>
 	</dependencies>
 
 </project>

--- a/camus-kafka-coders/src/test/java/com/linkedin/camus/etl/kafka/coders/TestJsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/test/java/com/linkedin/camus/etl/kafka/coders/TestJsonStringMessageDecoder.java
@@ -76,6 +76,36 @@ public class TestJsonStringMessageDecoder {
 
     }
 
+    @Test
+    public void testDecodeWithIsoFormat() {
+
+        // Test that when no format is specified then both
+        // ISO 8601 format: 1994-11-05T08:15:30-05:00
+        // and 1994-11-05T13:15:30Z are accepted
+
+        String testTimestamp1 = "1994-11-05T08:15:30-05:00";
+        String testTimestamp2 = "1994-11-05T13:15:30Z";
+        long expectedTimestamp = 784041330000L;
+
+        Properties testProperties = new Properties();
+
+        JsonStringMessageDecoder testDecoder = new JsonStringMessageDecoder();
+        testDecoder.init(testProperties, "testTopic");
+        String payload = "{\"timestamp\":  \"" + testTimestamp1 + "\", \"myData\": \"myValue\"}";
+        byte[] bytePayload = payload.getBytes();
+        CamusWrapper actualResult = testDecoder.decode(bytePayload);
+        long actualTimestamp = actualResult.getTimestamp();
+
+        assertEquals(expectedTimestamp, actualTimestamp);
+
+        payload = "{\"timestamp\":  \"" + testTimestamp2 + "\", \"myData\": \"myValue\"}";
+        bytePayload = payload.getBytes();
+        actualResult = testDecoder.decode(bytePayload);
+        actualTimestamp = actualResult.getTimestamp();
+
+        assertEquals(expectedTimestamp, actualTimestamp);
+    }
+
     @Test(expected = RuntimeException.class)
     public void testBadJsonInput() {
         byte[] bytePayload = "{\"key: value}".getBytes();


### PR DESCRIPTION
ISO standards support two types of format and libraries tend to pick one or the other depending on what they like. This PR adds support to parse ISO format so that both formats are supported.

@drdee @kengoodhope 
