### PR TITLE
Looks like the avro-1.7 SchemaParser was also called during this path, a...

### DIFF
--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/mapreduce/AvroKeyMapper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/mapreduce/AvroKeyMapper.java
@@ -15,6 +15,8 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.Mapper;
 
+import com.linkedin.camus.sweeper.utils.RelaxedAvroSerialization;
+
 public class AvroKeyMapper extends Mapper<AvroKey<GenericRecord>, NullWritable, AvroKey<GenericRecord>, Object>
 {
   private static final Log LOG =
@@ -35,7 +37,10 @@ public class AvroKeyMapper extends Mapper<AvroKey<GenericRecord>, NullWritable, 
     LOG.info("com.linkedin.events.fixed_16: " + loader.getResource("com/linkedin/events/fixed_16.class"));
     LOG.info("org.apache.avro.Schema: " + loader.getResource("org/apache/avro/Schema.class"));
 
-    keySchema = AvroJob.getMapOutputKeySchema(context.getConfiguration());
+    // We need to use RelaxedAvroSerialization to skip the illegal field names
+    // during schema parsing.
+    //keySchema = AvroJob.getMapOutputKeySchema(context.getConfiguration());
+    keySchema = RelaxedAvroSerialization.getKeyWriterSchema(context.getConfiguration());
 
     outValue = new AvroValue<GenericRecord>();
     outKey = new AvroKey<GenericRecord>();


### PR DESCRIPTION
...nd it cannot under the '@' chars in the field names (allowed in avro 1.4).

Use the RelaxedSchemaParser to get around this problem.

The stack trace when the error happened:

2014-11-01 09:14:52,842 WARN [Thread-5] org.apache.hadoop.mapred.YarnChild: Exception running child : org.apache.avro.SchemaParseException: Illegal initial character: @fields
        at org.apache.avro.Schema.validateName(Schema.java:1079)
        at org.apache.avro.Schema.access$200(Schema.java:79)
        at org.apache.avro.Schema$Field.<init>(Schema.java:372)
        at org.apache.avro.Schema.parse(Schema.java:1215)
        at org.apache.avro.Schema$Parser.parse(Schema.java:965)
        at org.apache.avro.Schema$Parser.parse(Schema.java:953)
        at org.apache.avro.Schema.parse(Schema.java:1005)
        at org.apache.avro.hadoop.io.AvroSerialization.getKeyWriterSchema(AvroSerialization.java:197)
        at org.apache.avro.mapreduce.AvroJob.getMapOutputKeySchema(AvroJob.java:174)
        at com.linkedin.camus.sweeper.mapreduce.AvroKeyMapper.setup(AvroKeyMapper.java:38)
