### PR TITLE
Add support for reporting module for camus etl

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -8,6 +8,8 @@ import com.linkedin.camus.etl.kafka.common.Source;
 import com.linkedin.camus.etl.kafka.mapred.EtlInputFormat;
 import com.linkedin.camus.etl.kafka.mapred.EtlMapper;
 import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
+import com.linkedin.camus.etl.kafka.logger.BaseReporter;
+import com.linkedin.camus.etl.kafka.logger.TimeReporter;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -60,6 +62,7 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.log4j.Logger;
@@ -94,6 +97,7 @@ public class CamusJob extends Configured implements Tool {
 	public static final String KAFKA_HOST_URL = "kafka.host.url";
 	public static final String KAFKA_HOST_PORT = "kafka.host.port";
 	public static final String KAFKA_TIMEOUT_VALUE = "kafka.timeout.value";
+	public static final String CAMUS_REPORTER_CLASS = "etl.reporter.class";
 	public static final String LOG4J_CONFIGURATION = "log4j.configuration";
 	private static org.apache.log4j.Logger log;
 
@@ -520,7 +524,8 @@ public class CamusJob extends Configured implements Tool {
 	}
 
 	/**
-	 * Creates a diagnostic report mostly focused on timing breakdowns. Useful
+	 * Creates a diagnostic report based on provided logger
+	 * defaults to TimeLogger which focusses on timing breakdowns. Useful
 	 * for determining where to optimize.
 	 * 
 	 * @param job
@@ -529,112 +534,8 @@ public class CamusJob extends Configured implements Tool {
 	 */
 	private void createReport(Job job, Map<String, Long> timingMap)
 			throws IOException {
-		StringBuilder sb = new StringBuilder();
-
-		sb.append("***********Timing Report*************\n");
-
-		sb.append("Job time (seconds):\n");
-
-		double preSetup = timingMap.get("pre-setup") / 1000;
-		double getSplits = timingMap.get("getSplits") / 1000;
-		double hadoop = timingMap.get("hadoop") / 1000;
-		double commit = timingMap.get("commit") / 1000;
-		double total = timingMap.get("total") / 1000;
-
-		sb.append(String.format("    %12s %6.1f (%s)\n", "pre setup", preSetup,
-				NumberFormat.getPercentInstance().format(preSetup / total)
-						.toString()));
-		sb.append(String.format("    %12s %6.1f (%s)\n", "get splits",
-				getSplits,
-				NumberFormat.getPercentInstance().format(getSplits / total)
-						.toString()));
-		sb.append(String.format("    %12s %6.1f (%s)\n", "hadoop job", hadoop,
-				NumberFormat.getPercentInstance().format(hadoop / total)
-						.toString()));
-		sb.append(String.format("    %12s %6.1f (%s)\n", "commit", commit,
-				NumberFormat.getPercentInstance().format(commit / total)
-						.toString()));
-
-		int minutes = (int) total / 60;
-		int seconds = (int) total % 60;
-
-		sb.append(String.format("Total: %d minutes %d seconds\n", minutes,
-				seconds));
-
-		JobClient client = new JobClient(new JobConf(job.getConfiguration()));
-
-		TaskReport[] tasks = client.getMapTaskReports(JobID.downgrade(job
-				.getJobID()));
-
-		double min = Long.MAX_VALUE, max = 0, mean = 0;
-		double minRun = Long.MAX_VALUE, maxRun = 0, meanRun = 0;
-		long totalTaskTime = 0;
-		TreeMap<Long, List<TaskReport>> taskMap = new TreeMap<Long, List<TaskReport>>();
-
-		for (TaskReport t : tasks) {
-			long wait = t.getStartTime() - timingMap.get("hadoop_start");
-			min = wait < min ? wait : min;
-			max = wait > max ? wait : max;
-			mean += wait;
-
-			long runTime = t.getFinishTime() - t.getStartTime();
-			totalTaskTime += runTime;
-			minRun = runTime < minRun ? runTime : minRun;
-			maxRun = runTime > maxRun ? runTime : maxRun;
-			meanRun += runTime;
-
-			if (!taskMap.containsKey(runTime)) {
-				taskMap.put(runTime, new ArrayList<TaskReport>());
-			}
-			taskMap.get(runTime).add(t);
-		}
-
-		mean /= tasks.length;
-		meanRun /= tasks.length;
-
-		// convert to seconds
-		min /= 1000;
-		max /= 1000;
-		mean /= 1000;
-		minRun /= 1000;
-		maxRun /= 1000;
-		meanRun /= 1000;
-
-		sb.append("\nHadoop job task times (seconds):\n");
-		sb.append(String.format("    %12s %6.1f\n", "min", minRun));
-		sb.append(String.format("    %12s %6.1f\n", "mean", meanRun));
-		sb.append(String.format("    %12s %6.1f\n", "max", maxRun));
-		sb.append(String.format("    %12s %6.1f/%.1f = %.2f\n", "skew",
-				meanRun, maxRun, meanRun / maxRun));
-
-		sb.append("\nTask wait time (seconds):\n");
-		sb.append(String.format("    %12s %6.1f\n", "min", min));
-		sb.append(String.format("    %12s %6.1f\n", "mean", mean));
-		sb.append(String.format("    %12s %6.1f\n", "max", max));
-
-		CounterGroup totalGrp = job.getCounters().getGroup("total");
-
-		long decode = totalGrp.findCounter("decode-time(ms)").getValue();
-		long request = totalGrp.findCounter("request-time(ms)").getValue();
-		long map = totalGrp.findCounter("mapper-time(ms)").getValue();
-		long mb = totalGrp.findCounter("data-read").getValue();
-
-		long other = totalTaskTime - map - request - decode;
-
-		sb.append("\nHadoop task breakdown:\n");
-		sb.append(String.format("    %12s %s\n", "kafka", NumberFormat
-				.getPercentInstance().format(request / (double) totalTaskTime)));
-		sb.append(String.format("    %12s %s\n", "decode", NumberFormat
-				.getPercentInstance().format(decode / (double) totalTaskTime)));
-		sb.append(String.format("    %12s %s\n", "map output", NumberFormat
-				.getPercentInstance().format(map / (double) totalTaskTime)));
-		sb.append(String.format("    %12s %s\n", "other", NumberFormat
-				.getPercentInstance().format(other / (double) totalTaskTime)));
-
-		sb.append(String.format("\n%16s %s\n", "Total MB read:",
-				mb / 1024 / 1024));
-
-		log.info(sb.toString());
+		Class cls = job.getConfiguration().getClass(getReporterClass(job), TimeReporter.class);
+		((BaseReporter)ReflectionUtils.newInstance(cls, job.getConfiguration())).report(job, timingMap);
 	}
 
 	/**
@@ -749,5 +650,9 @@ public class CamusJob extends Configured implements Tool {
 
 	public static boolean getLog4jConfigure(JobContext job) {
 		return job.getConfiguration().getBoolean(LOG4J_CONFIGURATION, false);
+	}
+
+	public static String getReporterClass(JobContext job) {
+		return job.getConfiguration().get(CAMUS_REPORTER_CLASS, "com.linkedin.camus.etl.kafka.logger.TimeReporter");
 	}
 }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/BaseReporter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/BaseReporter.java
@@ -1,0 +1,17 @@
+package com.linkedin.camus.etl.kafka.logger;
+
+import java.util.Map;
+import java.io.IOException;
+import org.apache.log4j.Logger;
+
+import org.apache.hadoop.mapreduce.Job;
+
+public abstract class BaseReporter {
+    public static org.apache.log4j.Logger log;
+
+    public BaseReporter() {
+        this.log = org.apache.log4j.Logger.getLogger(BaseReporter.class);
+    }
+
+    public abstract void report(Job job, Map<String, Long> timingMap) throws IOException;
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/TimeReporter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/TimeReporter.java
@@ -1,0 +1,128 @@
+package com.linkedin.camus.etl.kafka.logger;
+
+import java.util.Map;
+import java.io.IOException;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+
+import org.apache.hadoop.mapreduce.CounterGroup;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapred.JobClient;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobID;
+import org.apache.hadoop.mapred.TaskReport;
+
+import com.linkedin.camus.etl.kafka.logger.BaseReporter;
+
+public class TimeReporter extends BaseReporter {
+    public void report(Job job, Map<String, Long> timingMap) throws IOException {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("***********Timing Report*************\n");
+
+        sb.append("Job time (seconds):\n");
+
+        double preSetup = timingMap.get("pre-setup") / 1000;
+        double getSplits = timingMap.get("getSplits") / 1000;
+        double hadoop = timingMap.get("hadoop") / 1000;
+        double commit = timingMap.get("commit") / 1000;
+        double total = timingMap.get("total") / 1000;
+
+        sb.append(String.format("    %12s %6.1f (%s)\n", "pre setup", preSetup,
+            NumberFormat.getPercentInstance().format(preSetup / total)
+                .toString()));
+        sb.append(String.format("    %12s %6.1f (%s)\n", "get splits",
+            getSplits,
+            NumberFormat.getPercentInstance().format(getSplits / total)
+                .toString()));
+        sb.append(String.format("    %12s %6.1f (%s)\n", "hadoop job", hadoop,
+            NumberFormat.getPercentInstance().format(hadoop / total)
+                .toString()));
+        sb.append(String.format("    %12s %6.1f (%s)\n", "commit", commit,
+            NumberFormat.getPercentInstance().format(commit / total)
+                .toString()));
+
+        int minutes = (int) total / 60;
+        int seconds = (int) total % 60;
+
+        sb.append(String.format("Total: %d minutes %d seconds\n", minutes,
+            seconds));
+
+        JobClient client = new JobClient(new JobConf(job.getConfiguration()));
+
+        TaskReport[] tasks = client.getMapTaskReports(JobID.downgrade(job
+            .getJobID()));
+
+        double min = Long.MAX_VALUE, max = 0, mean = 0;
+        double minRun = Long.MAX_VALUE, maxRun = 0, meanRun = 0;
+        long totalTaskTime = 0;
+        TreeMap<Long, List<TaskReport>> taskMap = new TreeMap<Long, List<TaskReport>>();
+
+        for (TaskReport t : tasks) {
+          long wait = t.getStartTime() - timingMap.get("hadoop_start");
+          min = wait < min ? wait : min;
+          max = wait > max ? wait : max;
+          mean += wait;
+
+          long runTime = t.getFinishTime() - t.getStartTime();
+          totalTaskTime += runTime;
+          minRun = runTime < minRun ? runTime : minRun;
+          maxRun = runTime > maxRun ? runTime : maxRun;
+          meanRun += runTime;
+
+          if (!taskMap.containsKey(runTime)) {
+            taskMap.put(runTime, new ArrayList<TaskReport>());
+          }
+          taskMap.get(runTime).add(t);
+        }
+
+        mean /= tasks.length;
+        meanRun /= tasks.length;
+
+        // convert to seconds
+        min /= 1000;
+        max /= 1000;
+        mean /= 1000;
+        minRun /= 1000;
+        maxRun /= 1000;
+        meanRun /= 1000;
+
+        sb.append("\nHadoop job task times (seconds):\n");
+        sb.append(String.format("    %12s %6.1f\n", "min", minRun));
+        sb.append(String.format("    %12s %6.1f\n", "mean", meanRun));
+        sb.append(String.format("    %12s %6.1f\n", "max", maxRun));
+        sb.append(String.format("    %12s %6.1f/%.1f = %.2f\n", "skew",
+            meanRun, maxRun, meanRun / maxRun));
+
+        sb.append("\nTask wait time (seconds):\n");
+        sb.append(String.format("    %12s %6.1f\n", "min", min));
+        sb.append(String.format("    %12s %6.1f\n", "mean", mean));
+        sb.append(String.format("    %12s %6.1f\n", "max", max));
+
+        CounterGroup totalGrp = job.getCounters().getGroup("total");
+
+        long decode = totalGrp.findCounter("decode-time(ms)").getValue();
+        long request = totalGrp.findCounter("request-time(ms)").getValue();
+        long map = totalGrp.findCounter("mapper-time(ms)").getValue();
+        long mb = totalGrp.findCounter("data-read").getValue();
+
+        long other = totalTaskTime - map - request - decode;
+
+        sb.append("\nHadoop task breakdown:\n");
+        sb.append(String.format("    %12s %s\n", "kafka", NumberFormat
+            .getPercentInstance().format(request / (double) totalTaskTime)));
+        sb.append(String.format("    %12s %s\n", "decode", NumberFormat
+            .getPercentInstance().format(decode / (double) totalTaskTime)));
+        sb.append(String.format("    %12s %s\n", "map output", NumberFormat
+            .getPercentInstance().format(map / (double) totalTaskTime)));
+        sb.append(String.format("    %12s %s\n", "other", NumberFormat
+            .getPercentInstance().format(other / (double) totalTaskTime)));
+
+        sb.append(String.format("\n%16s %s\n", "Total MB read:",
+            mb / 1024 / 1024));
+
+        log.info(sb.toString());
+    }
+}

--- a/camus-example/src/main/resources/camus.properties
+++ b/camus-example/src/main/resources/camus.properties
@@ -30,7 +30,7 @@ kafka.message.coder.schema.registry.class=com.linkedin.camus.example.DummySchema
 mapred.map.tasks=30
 # max historical time that will be pulled from each partition based on event timestamp
 kafka.max.pull.hrs=1
-# events with a timestamp older than this will be discarded. 
+# events with a timestamp older than this will be discarded.
 kafka.max.historical.days=3
 # Max minutes for each mapper to pull messages (-1 means no limit)
 kafka.max.pull.minutes.per.task=-1
@@ -81,6 +81,9 @@ etl.default.timezone=America/Los_Angeles
 etl.output.file.time.partition.mins=60
 etl.keep.count.files=false
 etl.execution.history.max.of.quota=.8
+
+# Configures a customer reporter which extends BaseReporter to send etl data
+#etl.reporter.class
 
 mapred.output.compress=true
 mapred.map.max.attempts=1


### PR DESCRIPTION
Currently the only way to know details about the etl is through the log printed in timing report. Usually we would like to send this data to another service to track camus health.

This PR refactors reporting module so that a class can be set in camus.properties in order to send etl data. I also took the liberty cleanup camusjob class and refactor timing module as a reporter in order to serve as an example. At shopify we use it to send data to statsd in a custom class.

@drdee @kengoodhope 
