### PR TITLE
Set credentials for secure HDFS environments

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -159,8 +159,12 @@ public class CamusJob extends Configured implements Tool {
 	   {
 	     job.setJobName("Camus Job");
 	   }
-	   
-	  return job;
+
+		if (System.getenv("HADOOP_TOKEN_FILE_LOCATION") != null) {
+			job.getConfiguration().set("mapreduce.job.credentials.binary", System.getenv("HADOOP_TOKEN_FILE_LOCATION"));
+		}
+
+		return job;
 	}
 
 	public static void populateConf(Properties props, Configuration conf, Logger log) throws IOException {


### PR DESCRIPTION
As described in https://issues.apache.org/jira/browse/MAPREDUCE-4324 some job properties need to be set in secure environments. The copied approach is also used by Pig, Hive, etc.

Should work as before on non-secure environments.
