### PR TITLE
fixing group permission issue when mkdirs creates missing parent paths

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputCommitter.java
@@ -36,6 +36,13 @@ public class EtlMultiOutputCommitter extends FileOutputCommitter {
   private TaskAttemptContext context;
   private final RecordWriterProvider recordWriterProvider;
   private Logger log;
+  
+  private void mkdirs(FileSystem fs, Path path) throws IOException {
+    if (! fs.exists(path.getParent())) {
+      mkdirs(fs, path.getParent());
+    }
+    fs.mkdirs(path);
+  }
 
   public void addCounts(EtlKey key) throws IOException {
     String workingFileName = EtlMultiOutputFormat.getWorkingFileName(context, key);
@@ -101,7 +108,7 @@ public class EtlMultiOutputCommitter extends FileOutputCommitter {
           Path dest = new Path(baseOutDir, partitionedFile);
 
           if (!fs.exists(dest.getParent())) {
-            fs.mkdirs(dest.getParent());
+            mkdirs(fs, dest.getParent());
           }
 
           commitFile(context, f.getPath(), dest);


### PR DESCRIPTION
This addresses a bug/feature in HDFS where you create a directory and HDFS automatically creates any missing parent directories, but doesn't apply the correct permission.  The fix is to recurse up and then create a new directory one level at a time.
