### PR TITLE
Should not have scala-compiler on the class path.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-simple</artifactId>
                   </exclusion>
+                  <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-compiler</artifactId>
+                  </exclusion>
                 </exclusions>
             </dependency>
 			<dependency>


### PR DESCRIPTION
This also allows Maven to acutally put a more recent scala-library in the shaded jar. Before it took 2.10.1, now it takes 2.10.3 as expected from dependency management.
