### PR TITLE
Fix the class cast exception in EtlMultiOutputRecordWriter

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputRecordWriter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputRecordWriter.java
@@ -8,7 +8,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.SequenceFile.Writer;
-import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.log4j.Logger;
@@ -68,7 +67,7 @@ public class EtlMultiOutputRecordWriter extends RecordWriter<EtlKey, Object> {
         //TODO: fix this logging message, should be logged once as a total count of old records skipped for each topic
         // for now, commenting this out
         //log.warn("Key's time: " + key + " is less than beginTime: " + beginTimeStamp);
-        ((Mapper.Context) context).getCounter("total", "skip-old").increment(1);
+        context.getCounter("total", "skip-old").increment(1);
         committer.addOffset(key);
       } else {
         if (!key.getTopic().equals(currentTopic)) {


### PR DESCRIPTION
We saw the following exception when we received very old kafka message:

camus-hourly-Lix INFO - task error: Error: java.lang.ClassCastException: org.apache.hadoop.mapred.TaskAttemptContextImpl cannot be cast to org.apache.hadoop.mapreduce.Mapper$Context
18-12-2014 14:16:08 PST camus-hourly-Lix INFO - 	at com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputRecordWriter.write(EtlMultiOutputRecordWriter.java:87)

Actually there is no need to cast TaskAttemptContextImpl to Mapper$Context since TaskAttemptContextImpl have the getCounter method already.