### PR TITLE
Stop the pull when we noticed that the offset range from kafka metadata ...

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlRequest.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlRequest.java
@@ -35,7 +35,7 @@ public class EtlRequest implements CamusRequest {
 
   private static Logger log = Logger.getLogger(EtlRequest.class);
   private JobContext context = null;
-  private static final long DEFAULT_OFFSET = 0;
+  public static final long DEFAULT_OFFSET = 0;
 
   private String topic = "";
   private String leaderId = "";


### PR DESCRIPTION
...is out of the range of perviously saved offset checkpoint.  When this situation happens, it usually indicates a wrong configuration (or change) in kafka cluster which needs manual correction.

We also provide a config parameter kafka.move.to.earliest.offset, you can set this parameter to true to get back the old behavior (automatically falling back to earlierst offset from metadata)