### PR TITLE
Sweeper should not depend on the order of directory entries

### DIFF
--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
@@ -132,13 +132,13 @@ public class CamusSweeper extends Configured implements Tool {
   private static void findAllTopics(Path input, PathFilter filter, String topicSubdir, String topicNameSpace,
       FileSystem fs, Map<FileStatus, String> topics) throws IOException {
     for (FileStatus f : fs.listStatus(input)) {
-      String topicFullName = (topicNameSpace.isEmpty() ? "" : topicNameSpace + ".") + f.getPath().getParent().getName();
-      if (!f.isDir())
-        return;
-      if (f.getPath().getName().equals(topicSubdir) && filter.accept(f.getPath().getParent())) {
-        topics.put(fs.getFileStatus(f.getPath().getParent()), topicFullName);
-      } else {
-        findAllTopics(f.getPath(), filter, topicSubdir, topicFullName, fs, topics);
+      if (f.isDir()) {
+        String topicFullName = (topicNameSpace.isEmpty() ? "" : topicNameSpace + ".") + f.getPath().getParent().getName();
+        if (f.getPath().getName().equals(topicSubdir) && filter.accept(f.getPath().getParent())) {
+          topics.put(fs.getFileStatus(f.getPath().getParent()), topicFullName);
+        } else {
+          findAllTopics(f.getPath(), filter, topicSubdir, topicFullName, fs, topics);
+        }
       }
     }
   }


### PR DESCRIPTION
Currently, when sweeper analyses the source directory tree, it assumes that the first entry inside the topic directory is 1) a directory, 2) the source sub-directory.

Both are not necessarily true.
Assumption 2) fails when destination sub-directory (e.g. 'daily') lexically comes before the source sub-directory (e.g. 'recent'). (This can only happen when source and destination trees are the same.)
Assumption 1) fails under the edge case where additional files are kept in the topic directory (or in any sub-directory). I am storing some topic meta data in the topic directory so this assumption failed for me as well.

This change will make sweeper analyze the entire topic directory and not just the first entry.