### PR TITLE
Adding ISO-8601 parsing to JsonStringMessageDecoder

### DIFF
--- a/camus-example/src/main/resources/camus.properties
+++ b/camus-example/src/main/resources/camus.properties
@@ -34,6 +34,18 @@ camus.message.decoder.class=com.linkedin.batch.etl.kafka.coders.LatestSchemaKafk
 # com.linkedin.camus.example.schemaregistry.DummySchemaRegistry
 kafka.message.coder.schema.registry.class=com.linkedin.camus.example.DummySchemaRegistry
 
+# Used by JsonStringMessageDecoder when extracting the timestamp
+# Choose the field that holds the time stamp (default "timestamp")
+#camus.message.timestamp.field=time
+# What format is the timestamp in? Out of the box options are:
+# "unix" or "unix_seconds": The value will be read as a long containing the seconds since epoc
+# "unix_milliseconds": The value will be read as a long containing the milliseconds since epoc
+# "ISO-8601": Timestamps will be fed directly into org.joda.time.DateTime constructor, which reads ISO-8601
+# All other values will be fed into the java.text.SimpleDateFormat constructor, which will be used to parse the timestamps
+# Default is "[dd/MMM/yyyy:HH:mm:ss Z]"
+#camus.message.timestamp.format=yyyy-MM-dd_HH:mm:ss
+#camus.message.timestamp.format=ISO-8601
+
 # Used by the committer to arrange .avro files into a partitioned scheme. This will be the default partitioner for all
 # topic that do not have a partitioner specified.
 # Out of the box options are (for all options see the source for configuration options):

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonParser;
 import com.linkedin.camus.coders.CamusWrapper;
 import com.linkedin.camus.coders.MessageDecoder;
 import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
@@ -86,6 +87,15 @@ public class JsonStringMessageDecoder extends MessageDecoder<byte[], String> {
       // just save it as is.
       else if (timestampFormat.equals("unix_milliseconds")) {
         timestamp = jsonObject.get(timestampField).getAsLong();
+      }
+      // Else if timestampFormat is 'ISO-8601', parse that
+      else if (timestampFormat.equals("ISO-8601")) {
+        String timestampString = jsonObject.get(timestampField).getAsString();
+        try {
+          timestamp = new DateTime(timestampString).getMillis();
+        } catch (IllegalArgumentException e) {
+          log.error("Could not parse timestamp '" + timestampString + "' as ISO-8601 while decoding JSON message.");
+        }
       }
       // Otherwise parse the timestamp as a string in timestampFormat.
       else {


### PR DESCRIPTION
Allow another special case `camus.message.timestamp.format` value to pipe all timestamps to `org.joda.time.DateTime` constructor (which properly parses [ISO-8601][ISO-8601])

[ISO-8601]: http://www.iso.org/iso/home/standards/iso8601.htm