### PR TITLE
Minor clean up of the README's intro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Camus is LinkedIn's [Kafka](http://kafka.apache.org "Kafka")->HDFS pipeline. It 
 * Avro schema management / In progress
 * Date partitioning
 
-It is used at LinkedIn where it processes tens of billions of messages per day.
+It is used at LinkedIn where it processes tens of billions of messages per day. You can get a basic overview from this paper: [Building LinkedIn’s Real-time Activity Data Pipeline](http://sites.computer.org/debull/A12june/pipeline.pdf "Building LinkedIn’s Real-time Activity Data Pipeline").
 
-This is a new open source project, so we don't yet have detailed documentation available and there are still a few LinkedIn-specific items we haven't fixed yet. For early adopters, you can get a basic overview from this [Building LinkedIn’s Real-time Activity Data Pipeline](http://sites.computer.org/debull/A12june/pipeline.pdf "Building LinkedIn’s Real-time Activity Data Pipeline"). There is also a google group for discussion that you can email at camus_etl@googlegroups.com, <camus_etl@googlegroups.com> or you can search the [archives](https://groups.google.com/forum/#!forum/camus_etl "Camus Archives"). If you are interested please ask any questions on that mailing list.
+There is a [Google Groups mailing list](https://groups.google.com/forum/#!forum/camus_etl "Google Groups mailing list") that you can email or search if you have any questions.
 
 For a more detailed documentation on the main Camus components, please see [Camus InputFormat and OutputFormat Behavior](https://github.com/linkedin/camus/wiki/Camus-InputFormat-and-OutputFormat-Behavior "Camus InputFormat and OutputFormat Behavior")
 # Brief Overview


### PR DESCRIPTION
I think this change may help slightly to reduce our exposure to spam crawlers. There isn't any benefit to exposing the actual email address versus giving the link to subscribe to the group, since we'd like people to register on the group before posting anyway.

The previous text was also slightly messy.