### PR TITLE
reset pKey when message#key is null

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
@@ -117,6 +117,7 @@ public class KafkaReader {
         buf.get(bytes, buf.position(), origSize);
         pKey.set(bytes, 0, origSize);
       } else {
+        log.warn("Received message with null message.key(): " + msgAndOffset);
         pKey.setSize(0);
       }
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
@@ -116,6 +116,8 @@ public class KafkaReader {
         bytes = new byte[origSize];
         buf.get(bytes, buf.position(), origSize);
         pKey.set(bytes, 0, origSize);
+      } else {
+        pKey.setSize(0);
       }
 
       key.clear();


### PR DESCRIPTION
The pKey object is reused across messages, but is not being reset between each read. #getNext should empty pKey when it receives a message without a partition key.

This is kinda tricky to reproduce in a test :( Any ideas?