### PR TITLE
CachedSchemaRegistry to get the lastest schema from its cache

### DIFF
--- a/camus-api/src/main/java/com/linkedin/camus/schemaregistry/CachedSchemaRegistry.java
+++ b/camus-api/src/main/java/com/linkedin/camus/schemaregistry/CachedSchemaRegistry.java
@@ -36,7 +36,7 @@ public class CachedSchemaRegistry<S> implements SchemaRegistry<S> {
 			schema = registry.getLatestSchemaByTopic(topicName).getSchema();
 			cachedLatest.putIfAbsent(topicName, schema);
 		}
-		return registry.getLatestSchemaByTopic(topicName);
+		return schema;
 	}
 
 	public static class CachedSchemaTuple {


### PR DESCRIPTION
CachedSchemaRegistry is not using its cache to return the latest schema, it is requesting it everytime. This operation might be expensive. It should ensure it reads from its cache, just like for other schema's requests.
