### PR TITLE
CachedSchemaRegistry to get the lastest schema from its cache

### DIFF
--- a/camus-api/src/main/java/com/linkedin/camus/schemaregistry/CachedSchemaRegistry.java
+++ b/camus-api/src/main/java/com/linkedin/camus/schemaregistry/CachedSchemaRegistry.java
@@ -36,7 +36,7 @@ public class CachedSchemaRegistry<S> implements SchemaRegistry<S> {
 			schema = registry.getLatestSchemaByTopic(topicName).getSchema();
 			cachedLatest.putIfAbsent(topicName, schema);
 		}
-		return registry.getLatestSchemaByTopic(topicName);
+		return schema;
 	}
 
 	public static class CachedSchemaTuple {

--- a/camus-api/src/main/java/com/linkedin/camus/schemaregistry/CachedSchemaRegistry.java
+++ b/camus-api/src/main/java/com/linkedin/camus/schemaregistry/CachedSchemaRegistry.java
@@ -6,14 +6,14 @@ import java.util.concurrent.ConcurrentHashMap;
 public class CachedSchemaRegistry<S> implements SchemaRegistry<S> {
 	private final SchemaRegistry<S> registry;
 	private final ConcurrentHashMap<CachedSchemaTuple, S> cachedById;
-	private final ConcurrentHashMap<String, S> cachedLatest;
+	private final ConcurrentHashMap<String, SchemaDetails<S>> cachedLatest;
 	
 	public void init(Properties props) {}
 
 	public CachedSchemaRegistry(SchemaRegistry<S> registry) {
 		this.registry = registry;
 		this.cachedById = new ConcurrentHashMap<CachedSchemaTuple, S>();
-		this.cachedLatest = new ConcurrentHashMap<String, S>();
+		this.cachedLatest = new ConcurrentHashMap<String, SchemaDetails<S>>();
 	}
 
 	public String register(String topic, S schema) {
@@ -31,9 +31,9 @@ public class CachedSchemaRegistry<S> implements SchemaRegistry<S> {
 	}
 
 	public SchemaDetails<S> getLatestSchemaByTopic(String topicName) {
-		S schema = cachedLatest.get(topicName);
+		SchemaDetails<S> schema = cachedLatest.get(topicName);
 		if (schema == null) {
-			schema = registry.getLatestSchemaByTopic(topicName).getSchema();
+			schema = registry.getLatestSchemaByTopic(topicName);
 			cachedLatest.putIfAbsent(topicName, schema);
 		}
 		return schema;


### PR DESCRIPTION
CachedSchemaRegistry is not using its cache to return the latest schema, it is requesting it everytime instead. This might result in expensive operations. It should ensure it reads from its cache, just like for other schema's requests.