### PR TITLE
Etl2575 - Error handling in camus: publish error

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlCounts.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlCounts.java
@@ -38,6 +38,8 @@ public class EtlCounts {
   private static final String ERROR_COUNT = "errorCount";
   private static final String MONITORING_EVENT_CLASS = "monitoring.event.class";
 
+  public static final int NUM_TRIES_PUBLISH_COUNTS = 3;
+
   private String topic;
   private long startTime;
   private long granularity;
@@ -45,7 +47,7 @@ public class EtlCounts {
   private long endTime;
   private long lastTimestamp;
   private long firstTimestamp = Long.MAX_VALUE;
-  private HashMap<String, Source> counts;
+  protected HashMap<String, Source> counts;
 
   private transient EtlKey lastKey;
   private transient int eventCount = 0;
@@ -63,6 +65,11 @@ public class EtlCounts {
 
   public EtlCounts(String topic, long granularity) {
     this(topic, granularity, System.currentTimeMillis());
+  }
+
+  public EtlCounts(EtlCounts other) {
+    this(other.topic, other.granularity, other.startTime);
+    this.counts = other.counts;
   }
 
   public HashMap<String, Source> getCounts() {
@@ -198,8 +205,8 @@ public class EtlCounts {
 
       encoder.init(props, "TrackingMonitoringEvent");
       monitoringDetails =
-          (AbstractMonitoringEvent) Class.forName(conf.get(MONITORING_EVENT_CLASS))
-              .getDeclaredConstructor(Configuration.class).newInstance(conf);
+          (AbstractMonitoringEvent) Class.forName(getMonitoringEventClass(conf))
+          .getDeclaredConstructor(Configuration.class).newInstance(conf);
     } catch (Exception e1) {
       throw new RuntimeException(e1);
     }
@@ -229,6 +236,10 @@ public class EtlCounts {
     log.info(topic + " sent " + counts + " counts");
   }
 
+  protected String getMonitoringEventClass(Configuration conf) {
+    return conf.get(MONITORING_EVENT_CLASS);
+  }
+
   private void produceCount(String brokerList, ArrayList<byte[]> monitorSet) {
     // Shuffle the broker
 
@@ -238,22 +249,41 @@ public class EtlCounts {
     props.put("request.required.acks", "1");
     props.put("request.timeout.ms", "30000");
     log.debug("Broker list: " + brokerList);
-    Producer producer = new Producer(new ProducerConfig(props));
+
+    Producer producer = createProducer(props);
+
     try {
       for (byte[] message : monitorSet) {
-        KeyedMessage keyedMessage = new KeyedMessage("TrackingMonitoringEvent", message);
-        producer.send(keyedMessage);
+        for (int i = 0; i < NUM_TRIES_PUBLISH_COUNTS; i++) {
+          try {
+            KeyedMessage keyedMessage = new KeyedMessage("TrackingMonitoringEvent", message);
+            producer.send(keyedMessage);
+            break;
+          } catch (Exception e) {
+            log.error("Publishing count for topic " + topic + " to " + brokerList.toString() + " has failed " + (i + 1)
+                + " times. " + (NUM_TRIES_PUBLISH_COUNTS - i - 1) + " more attempts will be made.");
+            if (i == NUM_TRIES_PUBLISH_COUNTS - 1) {
+              throw new RuntimeException(e.getMessage() + ": " + "Have retried maximum ("
+                  + NUM_TRIES_PUBLISH_COUNTS + ") times.");
+            }
+            try {
+              Thread.sleep((long)(Math.random() * (i + 1) * 1000));
+            } catch (InterruptedException e1) {
+              log.error("Caught interrupted exception between retries of publishing counts to Kafka. "
+                  + e1.getMessage());
+            }
+          }
+        }
       }
-    } catch (Exception e) {
-      e.printStackTrace();
-      System.out.println(topic + " issue sending tracking to " + brokerList.toString());
-      throw new RuntimeException(e);
     } finally {
       if (producer != null) {
         producer.close();
       }
     }
+  }
 
+  protected Producer createProducer(Properties props) {
+    return new Producer(new ProducerConfig(props));
   }
 
 }

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTestWithMock.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTestWithMock.java
@@ -295,6 +295,7 @@ public class CamusJobTestWithMock {
     setupJobOffsetRangeCallThirdTrySucceed();
     job = new CamusJob(props);
     job.run(EtlInputFormatForUnitTest.class, EtlMultiOutputFormat.class);
+    verifyJobSucceed();
   }
 
   private void setupJobOffsetRangeCallThirdTrySucceed() {
@@ -422,6 +423,7 @@ public class CamusJobTestWithMock {
     props.setProperty(CamusJob.ETL_COUNTS_CLASS, "com.linkedin.camus.etl.kafka.common.EtlCountsForUnitTest");
     job = new CamusJob(props);
     job.run(EtlInputFormatForUnitTest.class, EtlMultiOutputFormat.class);
+    verifyJobSucceed();
   }
 
   private void setupJobPublishCountsThirdTimeSucceed() {

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTestWithMock.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTestWithMock.java
@@ -47,6 +47,7 @@ import org.junit.rules.TemporaryFolder;
 
 import com.google.gson.Gson;
 import com.linkedin.camus.etl.kafka.coders.JsonStringMessageDecoder;
+import com.linkedin.camus.etl.kafka.common.EtlCountsForUnitTest;
 import com.linkedin.camus.etl.kafka.common.SequenceFileRecordWriterProvider;
 import com.linkedin.camus.etl.kafka.mapred.EtlInputFormat;
 import com.linkedin.camus.etl.kafka.mapred.EtlInputFormatForUnitTest;
@@ -139,6 +140,7 @@ public class CamusJobTestWithMock {
     mocks.clear();
     EtlInputFormatForUnitTest.reset();
     EtlRecordReaderForUnitTest.reset();
+    EtlCountsForUnitTest.reset();
     Field field = EtlMultiOutputFormat.class.getDeclaredField("committer");
     field.setAccessible(true);
     field.set(null, null);
@@ -268,7 +270,6 @@ public class CamusJobTestWithMock {
     setupJobFailDueToOffsetRangeCallError();
     job = new CamusJob(props);
     job.run(EtlInputFormatForUnitTest.class, EtlMultiOutputFormat.class);
-    verifyJobSucceed();
   }
 
   private void setupJobFailDueToOffsetRangeCallError() {
@@ -390,6 +391,48 @@ public class CamusJobTestWithMock {
     props.setProperty(EtlInputFormat.KAFKA_MOVE_TO_EARLIEST_OFFSET, Boolean.FALSE.toString());
     job = new CamusJob(props);
     job.run(EtlInputFormatForUnitTest.class, EtlMultiOutputFormat.class);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testJobFailDueToPublishCountsException() throws Exception {
+    setupJobFailDueToPublishCountsException();
+    props.setProperty(EtlMultiOutputFormat.ETL_RUN_TRACKING_POST, Boolean.TRUE.toString());
+    props.setProperty(CamusJob.CAMUS_MESSAGE_ENCODER_CLASS, "com.linkedin.camus.etl.kafka.coders.EncoderForUnitTest");
+    props.setProperty(CamusJob.ETL_COUNTS_CLASS, "com.linkedin.camus.etl.kafka.common.EtlCountsForUnitTest");
+    job = new CamusJob(props);
+    job.run(EtlInputFormatForUnitTest.class, EtlMultiOutputFormat.class);
+  }
+
+  private void setupJobFailDueToPublishCountsException() {
+    TopicMetadataResponse metadataResponse = mockTopicMetaDataResponse();
+    List<MyMessage> myMessages = messagesWritten.get(TOPIC_1);
+    OffsetResponse offsetResponse = mockOffsetResponse(myMessages);
+    FetchResponse fetchResponse = mockFetchResponse(myMessages);
+    EtlInputFormatForUnitTest.consumerType = EtlInputFormatForUnitTest.ConsumerType.MOCK;
+    EtlInputFormatForUnitTest.consumer = mockSimpleConsumer(metadataResponse, offsetResponse, fetchResponse);
+    EtlCountsForUnitTest.producerType = EtlCountsForUnitTest.ProducerType.SEND_THROWS_EXCEPTION;
+    EasyMock.replay(mocks.toArray());
+  }
+
+  @Test
+  public void testJobPublishCountsThirdTimeSucceed() throws Exception {
+    setupJobPublishCountsThirdTimeSucceed();
+    props.setProperty(EtlMultiOutputFormat.ETL_RUN_TRACKING_POST, Boolean.TRUE.toString());
+    props.setProperty(CamusJob.CAMUS_MESSAGE_ENCODER_CLASS, "com.linkedin.camus.etl.kafka.coders.EncoderForUnitTest");
+    props.setProperty(CamusJob.ETL_COUNTS_CLASS, "com.linkedin.camus.etl.kafka.common.EtlCountsForUnitTest");
+    job = new CamusJob(props);
+    job.run(EtlInputFormatForUnitTest.class, EtlMultiOutputFormat.class);
+  }
+
+  private void setupJobPublishCountsThirdTimeSucceed() {
+    TopicMetadataResponse metadataResponse = mockTopicMetaDataResponse();
+    List<MyMessage> myMessages = messagesWritten.get(TOPIC_1);
+    OffsetResponse offsetResponse = mockOffsetResponse(myMessages);
+    FetchResponse fetchResponse = mockFetchResponse(myMessages);
+    EtlInputFormatForUnitTest.consumerType = EtlInputFormatForUnitTest.ConsumerType.MOCK;
+    EtlInputFormatForUnitTest.consumer = mockSimpleConsumer(metadataResponse, offsetResponse, fetchResponse);
+    EtlCountsForUnitTest.producerType = EtlCountsForUnitTest.ProducerType.SEND_SUCCEED_THIRD_TIME;
+    EasyMock.replay(mocks.toArray());
   }
 
   private void assertCamusContains(String topic) throws InstantiationException, IllegalAccessException, IOException {

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/coders/EncoderForUnitTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/coders/EncoderForUnitTest.java
@@ -1,0 +1,13 @@
+package com.linkedin.camus.etl.kafka.coders;
+
+import org.apache.avro.generic.IndexedRecord;
+
+import com.linkedin.camus.coders.MessageEncoder;
+
+public class EncoderForUnitTest extends MessageEncoder<IndexedRecord, byte[]> {
+
+  @Override
+  public byte[] toBytes(IndexedRecord record) {
+    return record.toString().getBytes();
+  }
+}

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/coders/GenericRecordForUnitTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/coders/GenericRecordForUnitTest.java
@@ -1,0 +1,37 @@
+package com.linkedin.camus.etl.kafka.coders;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+public class GenericRecordForUnitTest implements GenericRecord {
+
+  @Override
+  public void put(int i, Object v) {
+  }
+
+  @Override
+  public Object get(int i) {
+    return null;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return null;
+  }
+
+  @Override
+  public void put(String key, Object v) {
+
+  }
+
+  @Override
+  public Object get(String key) {
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return "genericRecordForUnitTest";
+  }
+
+}

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/coders/MonitoringEventForUnitTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/coders/MonitoringEventForUnitTest.java
@@ -1,0 +1,24 @@
+package com.linkedin.camus.etl.kafka.coders;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+
+import com.linkedin.camus.etl.kafka.common.AbstractMonitoringEvent;
+import com.linkedin.camus.etl.kafka.common.Source;
+
+public class MonitoringEventForUnitTest extends AbstractMonitoringEvent {
+
+  public MonitoringEventForUnitTest(Configuration config) {
+    super(config);
+  }
+
+  public MonitoringEventForUnitTest() {
+    super(new Configuration());
+  }
+
+  @Override
+  public GenericRecord createMonitoringEventRecord(Source countEntry, String topic, long granularity, String tier) {
+    return new GenericRecordForUnitTest();
+  }
+
+}

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/common/EtlCountsForUnitTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/common/EtlCountsForUnitTest.java
@@ -1,0 +1,74 @@
+package com.linkedin.camus.etl.kafka.common;
+
+import java.util.Properties;
+
+import kafka.javaapi.producer.Producer;
+import kafka.producer.KeyedMessage;
+import kafka.producer.ProducerConfig;
+
+import org.apache.hadoop.conf.Configuration;
+import org.easymock.EasyMock;
+
+import com.linkedin.camus.etl.kafka.CamusJobTestWithMock;
+
+
+public class EtlCountsForUnitTest extends EtlCounts {
+
+  public enum ProducerType {
+    REGULAR,
+    SEND_THROWS_EXCEPTION,
+    SEND_SUCCEED_THIRD_TIME;
+  }
+
+  public static ProducerType producerType = ProducerType.REGULAR;
+
+  public EtlCountsForUnitTest(EtlCounts other) {
+    super(other.getTopic(), other.getGranularity(), other.getStartTime());
+    this.counts = other.getCounts();
+  }
+
+  @Override
+  protected String getMonitoringEventClass(Configuration conf) {
+    return "com.linkedin.camus.etl.kafka.coders.MonitoringEventForUnitTest";
+  }
+
+  @Override
+  protected Producer createProducer(Properties props) {
+    switch (producerType) {
+      case REGULAR:
+        return new Producer(new ProducerConfig(props));
+      case SEND_THROWS_EXCEPTION:
+        return mockProducerSendThrowsException();
+      case SEND_SUCCEED_THIRD_TIME:
+        return mockProducerThirdSendSucceed();
+      default:
+        throw new RuntimeException("producer type not found");
+    }
+  }
+
+  private Producer mockProducerSendThrowsException() {
+    Producer mockProducer = EasyMock.createMock(Producer.class);
+    mockProducer.send((KeyedMessage) EasyMock.anyObject());
+    EasyMock.expectLastCall().andThrow(new RuntimeException("dummyException")).anyTimes();
+    mockProducer.close();
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.replay(mockProducer);
+    return mockProducer;
+  }
+
+  private Producer mockProducerThirdSendSucceed() {
+    Producer mockProducer = EasyMock.createMock(Producer.class);
+    mockProducer.send((KeyedMessage) EasyMock.anyObject());
+    EasyMock.expectLastCall().andThrow(new RuntimeException("dummyException")).times(2);
+    mockProducer.send((KeyedMessage) EasyMock.anyObject());
+    EasyMock.expectLastCall().times(1);
+    mockProducer.close();
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.replay(mockProducer);
+    return mockProducer;
+  }
+
+  public static void reset() {
+    producerType = ProducerType.REGULAR;
+  }
+}


### PR DESCRIPTION
- Retry if publish count to kafka fails.
- Fail job if max retires reached.