### PR TITLE
etl2566 - handling offset range call failure

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -390,6 +390,10 @@ public class CamusJob extends Configured implements Tool {
         && props.getProperty(ETL_FAIL_ON_ERRORS, Boolean.FALSE.toString()).equalsIgnoreCase(Boolean.TRUE.toString())) {
       throw new RuntimeException("Camus saw errors, check stderr");
     }
+
+    if (EtlInputFormat.reportJobFailureDueToSkippedMsg) {
+      throw new RuntimeException("Some topics skipped due to failure in getting latest offset from Kafka leaders.");
+    }
   }
 
   public void cancel() throws IOException {

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -392,6 +392,7 @@ public class CamusJob extends Configured implements Tool {
     }
 
     if (EtlInputFormat.reportJobFailureDueToSkippedMsg) {
+      EtlInputFormat.reportJobFailureDueToSkippedMsg = false;
       throw new RuntimeException("Some topics skipped due to failure in getting latest offset from Kafka leaders.");
     }
   }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -79,7 +79,7 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
   public static final String CAMUS_WORK_ALLOCATOR_CLASS = "camus.work.allocator.class";
   public static final String CAMUS_WORK_ALLOCATOR_DEFAULT = "com.linkedin.camus.workallocater.BaseAllocator";
 
-  public static final int FETCH_FROM_LEADER_MAX_RETRIES = 2;
+  public static final int FETCH_FROM_LEADER_MAX_RETRIES = 3;
 
   public static boolean reportJobFailureDueToSkippedMsg = false;
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -222,9 +222,17 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
           throw new RuntimeException();
         }
         return offsetResponse;
-      } catch (RuntimeException e) {
+      } catch (Exception e) {
         log.warn("Fetching offset from leader " + consumer.host() + ":" + consumer.port()
             + " has failed " + (i + 1) + " time(s). " + (FETCH_FROM_LEADER_MAX_RETRIES - i) + " retries left.");
+        if (i < FETCH_FROM_LEADER_MAX_RETRIES) {
+          try {
+            Thread.sleep(1000 * (i + 1));
+          } catch (InterruptedException e1) {
+            log.error("Caught interrupted exception between retries of getting latest offsets. "
+                + e1.getMessage());
+          }
+        }
       }
     }
     return null;

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -3,7 +3,6 @@ package com.linkedin.camus.etl.kafka.mapred;
 import com.linkedin.camus.coders.CamusWrapper;
 import com.linkedin.camus.coders.MessageDecoder;
 import com.linkedin.camus.etl.kafka.CamusJob;
-import com.linkedin.camus.etl.kafka.CamusJobTest;
 import com.linkedin.camus.etl.kafka.coders.KafkaAvroMessageDecoder;
 import com.linkedin.camus.etl.kafka.coders.MessageDecoderFactory;
 import com.linkedin.camus.etl.kafka.common.EtlKey;
@@ -83,7 +82,6 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
   public static final int FETCH_FROM_LEADER_MAX_RETRIES = 3;
 
   public static boolean reportJobFailureDueToSkippedMsg = false;
-  public static boolean useMockConsumerForUnitTest = false;
 
   private static Logger log = null;
 
@@ -218,9 +216,6 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 
   private OffsetResponse getLatestOffsetResponse(SimpleConsumer consumer,
       Map<TopicAndPartition, PartitionOffsetRequestInfo> offsetInfo, JobContext context) {
-    if (useMockConsumerForUnitTest) {
-      consumer = CamusJobTest.mockConsumer;
-    }
     for (int i = 0; i <= FETCH_FROM_LEADER_MAX_RETRIES; i++) {
       try {
         OffsetResponse offsetResponse = consumer.getOffsetsBefore(new OffsetRequest(offsetInfo,

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTest.java
@@ -121,8 +121,6 @@ public class CamusJobTest {
     // Run M/R for Hadoop1
     props.setProperty("mapreduce.jobtracker.address", "local");
 
-    EtlInputFormat.useMockConsumerForUnitTest = false;
-
     job = new CamusJob(props);
   }
 
@@ -150,18 +148,6 @@ public class CamusJobTest {
     assertCamusContains(TOPIC_3);
   }
 
-  @Test
-  public void testJobFailDueToOffsetRangeCallFailure() throws Exception {
-    EtlInputFormat.useMockConsumerForUnitTest = true;
-    createMockConsumer();
-    try {
-      job.run();
-      fail("Should have thrown RuntimeException: offset range call failed.");
-    } catch (RuntimeException e) {
-      String msg = "Some topics skipped due to failure in getting latest offset from Kafka leaders.";
-      assertEquals(msg, e.getMessage());
-    }
-  }
 
   @Test
   public void runJobWithErrors() throws Exception {

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTest.java
@@ -1,10 +1,8 @@
 package com.linkedin.camus.etl.kafka;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -17,9 +15,6 @@ import java.util.Properties;
 import java.util.Random;
 
 import com.linkedin.camus.etl.kafka.coders.FailDecoder;
-
-import kafka.javaapi.OffsetRequest;
-import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
 import kafka.producer.ProducerConfig;
@@ -32,7 +27,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -65,8 +59,6 @@ public class CamusJobTest {
   private static FileSystem fs;
   private static Gson gson;
   private static Map<String, List<Message>> messagesWritten;
-
-  public static SimpleConsumer mockConsumer;
 
   @BeforeClass
   public static void beforeClass() throws IOException {
@@ -130,7 +122,6 @@ public class CamusJobTest {
     folder.delete();
   }
 
-
   @Test
   public void runJob() throws Exception {
     job.run();
@@ -147,7 +138,6 @@ public class CamusJobTest {
     assertCamusContains(TOPIC_2);
     assertCamusContains(TOPIC_3);
   }
-
 
   @Test
   public void runJobWithErrors() throws Exception {
@@ -279,12 +269,4 @@ public class CamusJobTest {
     field.set(null, null);
   }
 
-  private static void createMockConsumer() {
-    mockConsumer = EasyMock.createNiceMock(SimpleConsumer.class);
-    EasyMock.expect(mockConsumer.getOffsetsBefore((OffsetRequest) EasyMock.anyObject()))
-      .andThrow(new RuntimeException()).anyTimes();
-    EasyMock.expect(mockConsumer.host()).andReturn("mockedHost").anyTimes();
-    EasyMock.expect(mockConsumer.port()).andReturn(0).anyTimes();
-    EasyMock.replay(mockConsumer);
-  }
 }


### PR DESCRIPTION
If unable to fetch latest offset from leader (response==null, response.hasError(), or caught runtime exception), retry three times. If still unable, skip the corresponding topics, proceed with other topics and report job failure.