### PR TITLE
Simple test to verify empty entries in white-/black-lists are handled correctly

### DIFF
--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormatTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormatTest.java
@@ -1,0 +1,26 @@
+package com.linkedin.camus.etl.kafka.mapred;
+
+import java.util.Arrays;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EtlInputFormatTest {
+
+  @Test
+  public void testEmptyWhitelistBlacklistEntries() {
+    Configuration conf = new Configuration();
+    conf.set(EtlInputFormat.KAFKA_WHITELIST_TOPIC, ",TopicA,TopicB,,TopicC,");
+    conf.set(EtlInputFormat.KAFKA_BLACKLIST_TOPIC, ",TopicD,TopicE,,,,,TopicF,");
+
+    String[] whitelistTopics = EtlInputFormat.getKafkaWhitelistTopic(conf);
+    Assert.assertEquals(Arrays.asList("TopicA", "TopicB", "TopicC"),
+                        Arrays.asList(whitelistTopics));
+
+    String[] blacklistTopics = EtlInputFormat.getKafkaBlacklistTopic(conf);
+    Assert.assertEquals(Arrays.asList("TopicD", "TopicE", "TopicF"),
+                        Arrays.asList(blacklistTopics));
+  }
+
+}


### PR DESCRIPTION
* Refactor EtlInputFormat.getKafkaWhitelistTopic()/getKafkaBlacklistTopic() to simplify testing
* Add a simple test to verify empty entries in whitelists/blacklists are handled correctly. This is important to be able to handle cases like:

kafka.blacklist.topics=${blacklist.topics.A},${blacklist.topics.B}
blacklist.topics.A=
blacklist.topics.B=TopicB1,TopicB2
