### PR TITLE
cache counter in EtlMultiOutputRecordWriter to avoid too many reflections

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputRecordWriter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputRecordWriter.java
@@ -30,7 +30,7 @@ public class EtlMultiOutputRecordWriter extends RecordWriter<EtlKey, Object> {
   private String currentTopic = "";
   private long beginTimeStamp = 0;
   private static Logger log = Logger.getLogger(EtlMultiOutputRecordWriter.class);
-  private static Counter topicSkipOldCounter = null;
+  private final Counter topicSkipOldCounter;
 
   private HashMap<String, RecordWriter<IEtlKey, CamusWrapper>> dataWriters =
       new HashMap<String, RecordWriter<IEtlKey, CamusWrapper>>();


### PR DESCRIPTION
cache the counter as a static variable "private static Counter topicSkipOldCounter". It is initialized in the constructor of EtlMultiOutputRecordWriter.