### PR TITLE
fix unit test

### DIFF
--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/CamusJobTest.java
@@ -121,9 +121,13 @@ public class CamusJobTest {
   }
 
   @After
-  public void after() throws IOException {
+  public void after() throws IOException, NoSuchFieldException, SecurityException, IllegalArgumentException,
+    IllegalAccessException {
     // Delete all camus data
     folder.delete();
+    Field field = EtlMultiOutputFormat.class.getDeclaredField("committer");
+    field.setAccessible(true);
+    field.set(null, null);
   }
 
   @Test


### PR DESCRIPTION
The after() method in CamusJobTest does not clean up properly, which caused problem for CamusJobTestWithMock.