### PR TITLE
make camus daily compaction work for hourly

### DIFF
--- a/camus-etl-kafka/build.gradle
+++ b/camus-etl-kafka/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	compile spec.external.junit
 	compile spec.external.snappyJava
 	compile spec.external.dogstatsd
-        compile spec.external.easymock
+  compile spec.external.easymock
 	compile fileTree(dir: '../lib', includes: ['*.jar'])
 }
  

--- a/camus-sweeper/build.gradle
+++ b/camus-sweeper/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compile spec.external.paranamer
 	compile spec.external.snappyJava
 	compile spec.external.junit
+	compile spec.external.easymock
 }
 
 classification="library"

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusCleaner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusCleaner.java
@@ -112,7 +112,7 @@ public class CamusCleaner extends Configured implements Tool {
 
     WhiteBlackListPathFilter filter = new WhiteBlackListPathFilter(whitelist, blacklist, sourcePath);
 
-    Map<FileStatus, String> topics = CamusSweeper.findAllTopics(sourcePath, filter, sourceSubDir, fs);
+    Map<FileStatus, String> topics = new CamusSweeper().findAllTopics(sourcePath, filter, sourceSubDir, fs);
 
     for (FileStatus status : topics.keySet()) {
       String name = status.getPath().getName();

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
@@ -1,0 +1,327 @@
+package com.linkedin.camus.sweeper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.Properties;
+import java.util.Map.Entry;
+import java.util.concurrent.Future;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.util.ToolRunner;
+import org.apache.log4j.Logger;
+
+import com.linkedin.camus.sweeper.mapreduce.CamusSweeperJob;
+import com.linkedin.camus.sweeper.utils.Utils;
+
+
+public class CamusHourlySweeper extends CamusSweeper {
+
+  private static final Logger LOG = Logger.getLogger(CamusHourlySweeper.class);
+
+  private static final String REDUCE_COUNT_OVERRIDE = "reduce.count.override.";
+  private static final String CAMUS_SWEEPER_TMP_DIR = "camus.sweeper.tmp.dir";
+  private static final String MAX_FILES = "max.files";
+  private static final int DEFAULT_MAX_FILES = 24;
+  private static final String TMP_PATH = "tmp.path";
+  private static final String CAMUS_SWEEPER_IO_CONFIGURER_CLASS = "camus.sweeper.io.configurer.class";
+  private static final String MAPRED_COMPRESS_MAP_OUTPUT = "mapred.compress.map.output";
+  private static final boolean DEFAULT_MAPRED_COMPRESS_MAP_OUTPUT = Boolean.TRUE;
+  private static final String REDUCER_COUNT = "reducer.count";
+  private static final int DEFAULT_REDUCER_COUNT = 45;
+  private static final String MAPRED_MIN_SPLIT_SIZE = "mapred.min.split.size";
+  private static final String MAPRED_MAX_SPLIT_SIZE = "mapred.max.split.size";
+
+  static final String TOPIC_AND_HOUR = "topic.and.hour";
+  static final String INPUT_PATHS = "input.paths";
+  static final String DEST_PATH = "dest.path";
+
+  private final CamusSweeperMetrics metrics;
+
+  public CamusHourlySweeper() {
+    super();
+    metrics = new CamusSweeperMetrics();
+  }
+
+  public CamusHourlySweeper(Properties props) {
+    super(props);
+    metrics = new CamusSweeperMetrics();
+  }
+
+  @Override
+  public Map<FileStatus, String> findAllTopics(Path input, PathFilter filter, String topicSubdir, FileSystem fs)
+      throws IOException {
+    Map<FileStatus, String> topics = new HashMap<FileStatus, String>();
+    for (FileStatus f : fs.listStatus(input)) {
+      if (f.isDir() && filter.accept(f.getPath())) {
+        LOG.info("found topic: " + f.getPath().getName());
+        topics.put(fs.getFileStatus(f.getPath()), f.getPath().getName());
+      }
+    }
+    return topics;
+  }
+
+  @Override
+  public void run() throws Exception {
+    metrics.timeStart = System.currentTimeMillis();
+    super.run();
+    reportMetrics();
+    addOutliers();
+  }
+
+  private void addOutliers() throws IOException {
+    Configuration conf = new Configuration();
+    for (Entry<Object, Object> pair : props.entrySet()) {
+      String key = (String) pair.getKey();
+      conf.set(key, (String) pair.getValue());
+    }
+    for (Properties jobProps : planner.getOutlierProperties()) {
+      this.executorService.submit(new OutlierCollectorRunner(jobProps, FileSystem.get(conf)));
+    }
+  }
+
+  private void reportMetrics() throws IllegalArgumentException, IOException {
+    LOG.info("reporting metrics");
+    metrics.reportTotalRunningTime();
+    metrics.reportTotalDataSize();
+    metrics.reportDataSizeByTopic();
+    metrics.reportDurationFromStartToRunnerStart();
+    metrics.reportDurationFromRunnerStartToMRSubmitted();
+    metrics.reportDurationFromMRSubmittedToMRStarted();
+    metrics.reportDurationFromMRStartedToMRFinished();
+    LOG.info("finished reporting metrics");
+  }
+
+  public static void main(String args[]) throws Exception {
+    CamusSweeper job = new CamusHourlySweeper();
+    ToolRunner.run(job, args);
+  }
+
+  @Override
+  protected Future<?> runCollector(Properties props, String topic) {
+    String jobName = topic + "-" + UUID.randomUUID().toString();
+    props.put("tmp.path", props.getProperty(CAMUS_SWEEPER_TMP_DIR) + "/" + jobName + "_" + System.currentTimeMillis());
+
+    if (props.containsKey(REDUCE_COUNT_OVERRIDE + topic))
+      props.put("reducer.count", Integer.parseInt(props.getProperty(REDUCE_COUNT_OVERRIDE + topic)));
+
+    LOG.info("Processing " + props.get(INPUT_PATHS));
+
+    return executorService.submit(new KafkaCollectorRunner(jobName, props, errorMessages, topic));
+  }
+
+  @Override
+  protected void runCollectorForTopicDir(FileSystem fs, String topic, Path topicSourceDir, Path topicDestDir)
+      throws Exception {
+    LOG.info("Running collector for topic " + topic + " source:" + topicSourceDir + " dest:" + topicDestDir);
+    List<Future<?>> tasksToComplete = new ArrayList<Future<?>>();
+
+    List<Properties> jobPropsList = planner.createSweeperJobProps(topic, topicSourceDir, topicDestDir, fs, metrics);
+
+    for (Properties jobProps : jobPropsList) {
+      tasksToComplete.add(runCollector(jobProps, topic));
+    }
+  }
+
+  private class KafkaCollectorRunner extends CamusSweeper.KafkaCollectorRunner {
+
+    public KafkaCollectorRunner(String name, Properties props, List<SweeperError> errorQueue, String topic) {
+      super(name, props, errorQueue, topic);
+    }
+
+    @Override
+    public void run() {
+      KafkaCollector collector = null;
+      try {
+        LOG.info("Starting runner for " + this.props.getProperty(TOPIC_AND_HOUR));
+        collector = new KafkaCollector(props, name, topic);
+        LOG.info("Running " + name + " for input " + props.getProperty(INPUT_PATHS));
+        collector.run();
+      } catch (Throwable e) { // Sometimes the error is the Throwable, e.g. java.lang.NoClassDefFoundError
+        e.printStackTrace();
+        LOG.error("Failed for " + name + " ,job: " + collector == null ? null : collector.getJob() + " failed for "
+            + props.getProperty(INPUT_PATHS) + " Exception:" + e.getLocalizedMessage());
+        errorQueue.add(new SweeperError(name, props.get(INPUT_PATHS).toString(), e));
+      }
+    }
+  }
+
+  private class KafkaCollector extends CamusSweeper.KafkaCollector {
+
+    private final String topicAndHour;
+    private final Path[] inputPaths;
+    private final Path tmpPath;
+    private final Path outputPath;
+    private final FileSystem fs;
+
+    public KafkaCollector(Properties props, String jobName, String topicName) throws IOException {
+      super(props, jobName, topicName);
+      this.topicAndHour = props.getProperty(TOPIC_AND_HOUR);
+      this.fs = FileSystem.get(job.getConfiguration());
+      this.inputPaths = getInputPaths();
+      this.tmpPath = new Path(job.getConfiguration().get(TMP_PATH));
+      this.outputPath = new Path(job.getConfiguration().get(DEST_PATH));
+      addInputAndOutputPathsToFileInputFormat();
+    }
+
+    private Path[] getInputPaths() {
+      List<String> strPaths = Utils.getStringList(props, INPUT_PATHS);
+      Path[] inputPaths = new Path[strPaths.size()];
+      for (int i = 0; i < strPaths.size(); i++)
+        inputPaths[i] = new Path(strPaths.get(i));
+      return inputPaths;
+    }
+
+    @Override
+    public void run() throws Exception {
+      CamusHourlySweeper.this.metrics.runnerStartTimeByTopic.put(this.topicAndHour, System.currentTimeMillis());
+
+      job.getConfiguration().setBoolean(MAPRED_COMPRESS_MAP_OUTPUT, DEFAULT_MAPRED_COMPRESS_MAP_OUTPUT);
+
+      ((CamusSweeperJob) Class.forName(props.getProperty(CAMUS_SWEEPER_IO_CONFIGURER_CLASS)).newInstance()).setLogger(
+          LOG).configureJob(topicName, job);
+
+      setNumOfReducersAndSplitSizes();
+      submitMrJob();
+      moveTmpPathToOutputPath();
+
+      CamusHourlySweeper.this.metrics.mrFinishTimeByTopic.put(this.topicAndHour, System.currentTimeMillis());
+    }
+
+    private void moveTmpPathToOutputPath() throws IOException {
+      Path oldPath = null;
+      if (fs.exists(outputPath)) {
+        oldPath = new Path("/tmp", "_old_" + job.getJobID());
+        moveExistingContentInOutputPathToOldPath(oldPath);
+      }
+
+      LOG.info("Moving " + tmpPath + " to " + outputPath);
+      mkdirs(fs, outputPath.getParent(), perm);
+
+      if (!fs.rename(tmpPath, outputPath)) {
+        fs.rename(oldPath, outputPath);
+        fs.delete(tmpPath, true);
+        throw new RuntimeException("Error: cannot rename " + tmpPath + " to " + outputPath);
+      }
+      deleteOldPath(oldPath);
+    }
+
+    private void deleteOldPath(Path oldPath) throws IOException {
+      if (oldPath != null && fs.exists(oldPath)) {
+        LOG.info("Deleting " + oldPath);
+        fs.delete(oldPath, true);
+      }
+    }
+
+    private void moveExistingContentInOutputPathToOldPath(Path oldPath) throws IOException {
+      LOG.info("Path " + outputPath + " exists. Overwriting.");
+      if (!fs.rename(outputPath, oldPath)) {
+        fs.delete(tmpPath, true);
+        throw new RuntimeException("Error: cannot rename " + outputPath + " to " + oldPath);
+      }
+    }
+
+    private void setNumOfReducersAndSplitSizes() throws IOException {
+      long inputSize = getInputSize();
+
+      int maxFiles = job.getConfiguration().getInt(MAX_FILES, DEFAULT_MAX_FILES);
+      int numTasks = Math.min((int) (inputSize / targetFileSize) + 1, maxFiles);
+
+      if (job.getNumReduceTasks() != 0) {
+        determineAndSetNumOfReducers(numTasks);
+      } else {
+        setSplitSizes(inputSize / numTasks);
+      }
+    }
+
+    private void submitMrJob() throws IOException, InterruptedException, ClassNotFoundException {
+      CamusHourlySweeper.this.metrics.mrSubmitTimeByTopic.put(this.topicAndHour, System.currentTimeMillis());
+      job.submit();
+      runningJobs.add(job);
+
+      CamusHourlySweeper.this.metrics.mrStartRunningTimeByTopic.put(this.topicAndHour, System.currentTimeMillis());
+
+      LOG.info("job running for: " + job.getConfiguration().get(TOPIC_AND_HOUR) + ", url: " + job.getTrackingURL());
+      job.waitForCompletion(false);
+      if (!job.isSuccessful()) {
+        throw new RuntimeException("hadoop job failed.");
+      }
+    }
+
+    private void setSplitSizes(long targetSplitSize) {
+      LOG.info("Setting target split size " + targetSplitSize);
+      job.getConfiguration().setLong(MAPRED_MAX_SPLIT_SIZE, targetSplitSize);
+      job.getConfiguration().setLong(MAPRED_MIN_SPLIT_SIZE, targetSplitSize);
+    }
+
+    private void determineAndSetNumOfReducers(int numTasks) {
+      int numReducers;
+      if (job.getConfiguration().get(REDUCER_COUNT) != null) {
+        numReducers = job.getConfiguration().getInt(REDUCER_COUNT, DEFAULT_REDUCER_COUNT);
+      } else {
+        numReducers = numTasks;
+      }
+      job.setNumReduceTasks(numReducers);
+    }
+
+    private long getInputSize() throws IOException {
+      long inputSize = 0;
+      for (Path p : inputPaths) {
+        LOG.info("inputPath: " + p.toString() + ", size=" + fs.getContentSummary(p).getLength());
+        inputSize += fs.getContentSummary(p).getLength();
+      }
+      return inputSize;
+    }
+
+    private void addInputAndOutputPathsToFileInputFormat() throws IOException {
+      for (Path path : inputPaths) {
+        FileInputFormat.addInputPath(job, path);
+        FileOutputFormat.setOutputPath(job, tmpPath);
+      }
+    }
+  }
+
+  private class OutlierCollectorRunner implements Runnable {
+
+    private final Properties props;
+    private final FileSystem fs;
+
+    public OutlierCollectorRunner(Properties props, FileSystem fs) {
+      this.props = props;
+      this.fs = fs;
+    }
+
+    @Override
+    public void run() {
+      String inputPaths = this.props.getProperty(CamusHourlySweeper.INPUT_PATHS);
+      String outputPathStr = this.props.getProperty(CamusHourlySweeper.DEST_PATH);
+      Path outputPath = new Path(outputPathStr, "outlier");
+
+      try {
+        fs.mkdirs(outputPath);
+        long destinationModTime = fs.getFileStatus(new Path(outputPathStr)).getModificationTime();
+
+        for (String inputPathStr : inputPaths.split(",")) {
+          Path inputPath = new Path(inputPathStr);
+          for (FileStatus status : fs.globStatus(new Path(inputPath, "*"), new HiddenFilter())) {
+            if (status.getModificationTime() > destinationModTime) {
+              LOG.info("moving " + status.getPath() + " to " + outputPath);
+              fs.rename(status.getPath(), new Path(outputPath, status.getPath().getName()));
+            }
+          }
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
@@ -187,8 +187,6 @@ public class CamusHourlySweeper extends CamusSweeper {
       setNumOfReducersAndSplitSizes();
       submitMrJob();
       moveTmpPathToOutputPath();
-
-      CamusHourlySweeper.this.metrics.recordMrFinishTimeByTopic(this.topicAndHour, System.currentTimeMillis());
     }
 
     @Override
@@ -199,8 +197,9 @@ public class CamusHourlySweeper extends CamusSweeper {
 
       CamusHourlySweeper.this.metrics.recordMrStartRunningTimeByTopic(this.topicAndHour, System.currentTimeMillis());
 
-      LOG.info("job running for: " + job.getConfiguration().get(TOPIC_AND_HOUR) + ", url: " + job.getTrackingURL());
+      LOG.info("job running for: " + props.getProperty(TOPIC_AND_HOUR) + ", url: " + job.getTrackingURL());
       job.waitForCompletion(false);
+      CamusHourlySweeper.this.metrics.recordMrFinishTimeByTopic(this.topicAndHour, System.currentTimeMillis());
       if (!job.isSuccessful()) {
         throw new RuntimeException("hadoop job failed.");
       }

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
@@ -204,7 +204,6 @@ public class CamusHourlySweeper extends CamusSweeper {
         throw new RuntimeException("hadoop job failed.");
       }
     }
-
   }
 
   private class OutlierCollectorRunner implements Callable<Void> {

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
@@ -70,14 +70,9 @@ public class CamusHourlySweeper extends CamusSweeper {
   }
 
   private void addOutliers() throws IOException {
-    Configuration conf = new Configuration();
-    for (Entry<Object, Object> pair : props.entrySet()) {
-      String key = (String) pair.getKey();
-      conf.set(key, (String) pair.getValue());
-    }
     createExecutorService();
     for (Properties jobProps : planner.getOutlierProperties()) {
-      this.executorService.submit(new OutlierCollectorRunner(jobProps, FileSystem.get(conf)));
+      this.executorService.submit(new OutlierCollectorRunner(jobProps, FileSystem.get(getConf())));
     }
     this.executorService.shutdown();
   }
@@ -150,7 +145,6 @@ public class CamusHourlySweeper extends CamusSweeper {
         LOG.info("Running " + name + " for input " + props.getProperty(INPUT_PATHS));
         collector.run();
       } catch (Throwable e) { // Sometimes the error is the Throwable, e.g. java.lang.NoClassDefFoundError
-        e.printStackTrace();
         LOG.error("Failed for " + name + " ,job: " + collector == null ? null : collector.getJob() + " failed for "
             + props.getProperty(INPUT_PATHS) + " Exception:" + e.getLocalizedMessage());
         errorQueue.add(new SweeperError(name, props.get(INPUT_PATHS).toString(), e));

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlanner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlanner.java
@@ -1,0 +1,133 @@
+package com.linkedin.camus.sweeper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
+
+import com.linkedin.camus.sweeper.utils.DateUtils;
+
+
+public class CamusHourlySweeperPlanner extends CamusSweeperPlanner {
+  private static final String CAMUS_HOURLY_SWEEPER_MAX_HOURS_AGO = "camus.hourly.sweeper.max.hours.ago";
+  private static final String DEFAULT_CAMUS_HOURLY_SWEEPER_MAX_HOURS_AGO = "1";
+  private static final String CAMUS_HOURLY_SWEEPER_MIN_HOURS_AGO = "camus.hourly.sweeper.min.hours.ago";
+  private static final String DEFAULT_CAMUS_HOURLY_SWEEPER_MIN_HOURS_AGO = "1";
+
+  private static final Logger LOG = Logger.getLogger(CamusHourlySweeperPlanner.class);
+
+  private DateTimeFormatter hourFormatter;
+  private DateUtils dUtils;
+
+  @Override
+  public CamusSweeperPlanner setPropertiesLogger(Properties props, Logger log) {
+    dUtils = new DateUtils(props);
+    hourFormatter = dUtils.getDateTimeFormatter("YYYY/MM/dd/HH");
+    return super.setPropertiesLogger(props, log);
+  }
+
+  private DateTime getFolderHour(Path datePath, Path inputDir) {
+    String datePathStr = datePath.toString();
+    String inputDirStr = inputDir.toString();
+    String dateStr = datePathStr.substring(datePathStr.indexOf(inputDirStr) + inputDirStr.length());
+    return hourFormatter.parseDateTime(dateStr.replaceAll("^/", ""));
+  }
+
+  @Override
+  public List<Properties> createSweeperJobProps(String topic, Path inputDir, Path outputDir, FileSystem fs)
+      throws IOException {
+    return createSweeperJobProps(topic, inputDir, outputDir, fs, new CamusSweeperMetrics());
+  }
+
+  @Override
+  protected List<Properties> createSweeperJobProps(String topic, Path inputDir, Path outputDir, FileSystem fs,
+      CamusSweeperMetrics metrics) throws IOException {
+    LOG.info("creating hourly sweeper job props: topic=" + topic + ", inputDir=" + inputDir + ", outputDir="
+        + outputDir);
+    List<Properties> jobPropsList = new ArrayList<Properties>();
+    if (!fs.exists(inputDir)) {
+      LOG.warn("inputdir " + inputDir + " does not exist. Skipping topic " + topic);
+      return jobPropsList;
+    }
+
+    for (FileStatus f : fs.globStatus(new Path(inputDir, "*/*/*/*"))) {
+
+      DateTime folderHour = getFolderHour(f.getPath(), inputDir);
+      if (shouldProcessHour(folderHour)) {
+        Properties jobProps = createJobProps(topic, f.getPath(), folderHour, outputDir, fs, metrics);
+        if (jobProps != null) {
+          jobPropsList.add(jobProps);
+        }
+      }
+    }
+
+    return jobPropsList;
+  }
+
+  private Properties createJobProps(String topic, Path folder, DateTime folderHour, Path outputDir, FileSystem fs,
+      CamusSweeperMetrics metrics) throws IOException {
+
+    Properties jobProps = new Properties(props);
+    jobProps.putAll(props);
+
+    jobProps.put("topic", topic);
+
+    String topicAndHour = topic + ":" + folderHour.toString(hourFormatter);
+    jobProps.put(CamusHourlySweeper.TOPIC_AND_HOUR, topicAndHour);
+
+    long dataSize = fs.getContentSummary(folder).getLength();
+    metrics.dataSizeByTopic.put(topicAndHour, dataSize);
+    metrics.totalDataSize += dataSize;
+
+    List<Path> sourcePaths = new ArrayList<Path>();
+    sourcePaths.add(folder);
+
+    Path destPath = new Path(outputDir, folderHour.toString(hourFormatter));
+
+    jobProps.put(CamusHourlySweeper.INPUT_PATHS, pathListToCommaSeperated(sourcePaths));
+    jobProps.put(CamusHourlySweeper.DEST_PATH, destPath.toString());
+
+    if (!fs.exists(destPath)) {
+      LOG.info(topic + " dest dir " + destPath.toString() + " doesn't exist. Processing.");
+      return jobProps;
+    } else if (sourceDirHasOutliers(fs, sourcePaths, destPath)) {
+      LOG.info("found outliers for topic " + topic + ". Will add outliers to " + destPath.toString());
+      this.outlierProperties.add(jobProps);
+      return null;
+    } else {
+      LOG.info(topic + " dest dir " + destPath.toString() + " already exists. Skipping.");
+      return null;
+    }
+  }
+
+  private boolean sourceDirHasOutliers(FileSystem fs, List<Path> sourcePaths, Path destPath) throws IOException {
+    long destinationModTime = fs.getFileStatus(destPath).getModificationTime();
+    for (Path source : sourcePaths) {
+      for (FileStatus status : fs.globStatus(new Path(source, "*"), new HiddenFilter())) {
+        if (status.getModificationTime() > destinationModTime) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private boolean shouldProcessHour(DateTime folderHour) {
+    DateTime currentHour = dUtils.getCurrentHour();
+    DateTime maxHoursAgo =
+        currentHour.minusHours(Integer.parseInt(props.getProperty(CAMUS_HOURLY_SWEEPER_MAX_HOURS_AGO,
+            DEFAULT_CAMUS_HOURLY_SWEEPER_MAX_HOURS_AGO)));
+    DateTime minHoursAgo =
+        currentHour.minusHours(Integer.parseInt(props.getProperty(CAMUS_HOURLY_SWEEPER_MIN_HOURS_AGO,
+            DEFAULT_CAMUS_HOURLY_SWEEPER_MIN_HOURS_AGO)));
+    return (folderHour.isAfter(maxHoursAgo) || folderHour.isEqual(maxHoursAgo))
+        && (folderHour.isBefore(minHoursAgo) || folderHour.isEqual(minHoursAgo));
+  }
+}

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlanner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlanner.java
@@ -16,6 +16,7 @@ import com.linkedin.camus.sweeper.utils.DateUtils;
 
 
 public class CamusHourlySweeperPlanner extends CamusSweeperPlanner {
+  private static final String HOURLY_FOLDER_STRUCTURE = "*/*/*/*";
   private static final String YYYY_MM_DD_HH = "YYYY/MM/dd/HH";
   private static final String CAMUS_HOURLY_SWEEPER_MAX_HOURS_AGO = "camus.hourly.sweeper.max.hours.ago";
   private static final String DEFAULT_CAMUS_HOURLY_SWEEPER_MAX_HOURS_AGO = "1";
@@ -62,7 +63,7 @@ public class CamusHourlySweeperPlanner extends CamusSweeperPlanner {
       return jobPropsList;
     }
 
-    for (FileStatus f : fs.globStatus(new Path(inputDir, "*/*/*/*"))) {
+    for (FileStatus f : fs.globStatus(new Path(inputDir, HOURLY_FOLDER_STRUCTURE))) {
 
       DateTime folderHour = getFolderHour(f.getPath(), inputDir);
       if (shouldProcessHour(folderHour)) {
@@ -79,7 +80,7 @@ public class CamusHourlySweeperPlanner extends CamusSweeperPlanner {
   private Properties createJobProps(String topic, Path folder, DateTime folderHour, Path outputDir, FileSystem fs,
       CamusSweeperMetrics metrics) throws IOException {
 
-    Properties jobProps = new Properties(props);
+    Properties jobProps = new Properties();
     jobProps.putAll(props);
 
     jobProps.put("topic", topic);

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
@@ -149,11 +149,14 @@ public class CamusSweeper extends Configured implements Tool {
     }
   }
 
+  protected void createExecutorService() {
+    int numThreads = Integer.parseInt(props.getProperty("num.threads", DEFAULT_NUM_THREADS));
+    executorService = new PriorityExecutor(numThreads);
+  }
+
   public void run() throws Exception {
     log.info("Starting kafka sweeper");
-    int numThreads = Integer.parseInt(props.getProperty("num.threads", DEFAULT_NUM_THREADS));
-
-    executorService = new PriorityExecutor(numThreads);
+    createExecutorService();
 
     String fromLocation = (String) props.getProperty("camus.sweeper.source.dir");
     String destLocation = (String) props.getProperty("camus.sweeper.dest.dir", "");

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperDatePartitionPlanner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperDatePartitionPlanner.java
@@ -2,7 +2,6 @@ package com.linkedin.camus.sweeper;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
@@ -17,7 +16,7 @@ import com.linkedin.camus.sweeper.utils.DateUtils;
 
 
 public class CamusSweeperDatePartitionPlanner extends CamusSweeperPlanner {
-  private static final Logger _log = Logger.getLogger(CamusSweeperDatePartitionPlanner.class);
+  private static final Logger LOG = Logger.getLogger(CamusSweeperDatePartitionPlanner.class);
 
   private DateTimeFormatter dayFormatter;
   private DateUtils dUtils;
@@ -34,20 +33,6 @@ public class CamusSweeperDatePartitionPlanner extends CamusSweeperPlanner {
     String inputDirStr = inputDir.toString();
     String dateStr = datePathStr.substring(datePathStr.indexOf(inputDirStr) + inputDirStr.length());
     return dayFormatter.parseDateTime(dateStr.replaceAll("^/", ""));
-  }
-
-  private String pathListToCommaSeperated(List<Path> list) {
-    ArrayList<Path> tmpList = new ArrayList<Path>();
-    tmpList.addAll(list);
-
-    StringBuilder sb = new StringBuilder(tmpList.get(0).toString());
-    tmpList.remove(0);
-
-    for (Path p : tmpList) {
-      sb.append(",").append(p.toString());
-    }
-
-    return sb.toString();
   }
 
   @Override
@@ -76,22 +61,27 @@ public class CamusSweeperDatePartitionPlanner extends CamusSweeperPlanner {
         jobProps.put("dest.path", destPath.toString());
 
         if (!fs.exists(destPath)) {
-          _log.info(topic + " dest dir " + destPath.toString() + " doesn't exist or . Processing.");
+          LOG.info(topic + " dest dir " + destPath.toString() + " doesn't exist or . Processing.");
           jobPropsList.add(jobProps);
         } else if (shouldReprocess(fs, sourcePaths, destPath)) {
-          _log.info(topic + " dest dir " + destPath.toString()
-              + " has a modified time before the source. Reprocessing.");
+          LOG.info(topic + " dest dir " + destPath.toString() + " has a modified time before the source. Reprocessing.");
           sourcePaths.add(destPath);
           jobProps.put("input.paths", pathListToCommaSeperated(sourcePaths));
           jobPropsList.add(jobProps);
         } else {
-          _log.info(topic + " skipping " + destPath.toString());
+          LOG.info(topic + " skipping " + destPath.toString());
         }
       }
     }
 
     return jobPropsList;
 
+  }
+
+  @Override
+  protected List<Properties> createSweeperJobProps(String topic, Path inputDir, Path outputDir, FileSystem fs,
+      CamusSweeperMetrics metrics) throws IOException {
+    return createSweeperJobProps(topic, inputDir, outputDir, fs);
   }
 
 }

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperMetrics.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperMetrics.java
@@ -15,14 +15,14 @@ public class CamusSweeperMetrics {
 
   private static final Logger LOG = Logger.getLogger(CamusSweeperMetrics.class);
 
-  final Map<String, Long> dataSizeByTopic;
-  final Map<String, Long> runnerStartTimeByTopic;
-  final Map<String, Long> mrSubmitTimeByTopic;
-  final Map<String, Long> mrStartRunningTimeByTopic;
-  final Map<String, Long> mrFinishTimeByTopic;
+  private final Map<String, Long> dataSizeByTopic;
+  private final Map<String, Long> runnerStartTimeByTopic;
+  private final Map<String, Long> mrSubmitTimeByTopic;
+  private final Map<String, Long> mrStartRunningTimeByTopic;
+  private final Map<String, Long> mrFinishTimeByTopic;
 
-  long totalDataSize;
-  long timeStart;
+  private long totalDataSize;
+  private long timeStart;
 
   CamusSweeperMetrics() {
     this.dataSizeByTopic = new ConcurrentHashMap<String, Long>();
@@ -32,6 +32,42 @@ public class CamusSweeperMetrics {
     this.mrStartRunningTimeByTopic = new ConcurrentHashMap<String, Long>();
     timeStart = 0;
     totalDataSize = 0;
+  }
+
+  public long getTotalDataSize() {
+    return totalDataSize;
+  }
+
+  public void addToTotalDataSize(long size) {
+    this.totalDataSize += size;
+  }
+
+  public long getTimeStart() {
+    return timeStart;
+  }
+
+  public void setTimeStart(long timeStart) {
+    this.timeStart = timeStart;
+  }
+
+  public void recordDataSizeByTopic(String topic, long dataSize) {
+    this.dataSizeByTopic.put(topic, dataSize);
+  }
+
+  public void recordRunnerStartTimeByTopic(String topic, long time) {
+    this.runnerStartTimeByTopic.put(topic, time);
+  }
+
+  public void recordMrSubmitTimeByTopic(String topic, long time) {
+    this.mrSubmitTimeByTopic.put(topic, time);
+  }
+
+  public void recordMrStartRunningTimeByTopic(String topic, long time) {
+    this.mrStartRunningTimeByTopic.put(topic, time);
+  }
+
+  public void recordMrFinishTimeByTopic(String topic, long time) {
+    this.mrFinishTimeByTopic.put(topic, time);
   }
 
   public void reportTotalRunningTime() {

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperMetrics.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperMetrics.java
@@ -1,0 +1,134 @@
+package com.linkedin.camus.sweeper;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+
+
+public class CamusSweeperMetrics {
+
+  private static final Logger LOG = Logger.getLogger(CamusSweeperMetrics.class);
+
+  final Map<String, Long> dataSizeByTopic;
+  final Map<String, Long> runnerStartTimeByTopic;
+  final Map<String, Long> mrSubmitTimeByTopic;
+  final Map<String, Long> mrStartRunningTimeByTopic;
+  final Map<String, Long> mrFinishTimeByTopic;
+
+  long totalDataSize;
+  long timeStart;
+
+  CamusSweeperMetrics() {
+    this.dataSizeByTopic = new HashMap<String, Long>();
+    this.mrSubmitTimeByTopic = new HashMap<String, Long>();
+    this.mrFinishTimeByTopic = new HashMap<String, Long>();
+    this.runnerStartTimeByTopic = new HashMap<String, Long>();
+    this.mrStartRunningTimeByTopic = new HashMap<String, Long>();
+    timeStart = 0;
+    totalDataSize = 0;
+  }
+
+  public void reportTotalRunningTime() {
+    LOG.info("total running time: " + (System.currentTimeMillis() - this.timeStart) / 1000L + " sec");
+  }
+
+  public void reportTotalDataSize() {
+    double totalDataSizeGB = (double) this.totalDataSize / 1024.0 / 1024.0 / 1024.0;
+    LOG.info("total data size: " + String.format("%.2f", totalDataSizeGB) + "GB");
+  }
+
+  public void reportDataSizeByTopic() {
+    this.reportDataSizeByTopic(Integer.MAX_VALUE);
+  }
+
+  public void reportDataSizeByTopic(int maxToReport) {
+    LOG.info("Data Size By Topic:");
+    List<Map.Entry<String, Long>> dataSizeByTopicSorted = sortByValueDesc(this.dataSizeByTopic);
+    for (int i = 0; i < dataSizeByTopicSorted.size() && i < maxToReport; i++) {
+      Map.Entry<String, Long> entry = dataSizeByTopicSorted.get(i);
+      double dataSizeMB = (double) entry.getValue() / 1024.0 / 1024.0;
+      LOG.info("  " + entry.getKey() + ": " + String.format("%.2f", dataSizeMB) + "MB");
+    }
+  }
+
+  public void reportDurationFromStartToRunnerStart() {
+    this.reportDurationFromStartToRunnerStart(Integer.MAX_VALUE);
+  }
+
+  public void reportDurationFromStartToRunnerStart(int maxToReport) {
+    LOG.info("Time from start processing to runner starts By Topic:");
+    Map<String, Long> durations = getDurations(this.timeStart, this.runnerStartTimeByTopic);
+    reportDurations(durations, maxToReport);
+  }
+
+  public void reportDurationFromRunnerStartToMRSubmitted() {
+    this.reportDurationFromRunnerStartToMRSubmitted(Integer.MAX_VALUE);
+  }
+
+  public void reportDurationFromRunnerStartToMRSubmitted(int maxToReport) {
+    LOG.info("Time from runner start to MR submitted By Topic:");
+    Map<String, Long> durations = getDurations(this.runnerStartTimeByTopic, this.mrSubmitTimeByTopic);
+    reportDurations(durations, maxToReport);
+  }
+
+  public void reportDurationFromMRSubmittedToMRStarted() {
+    this.reportDurationFromMRSubmittedToMRStarted(Integer.MAX_VALUE);
+  }
+
+  public void reportDurationFromMRSubmittedToMRStarted(int maxToReport) {
+    LOG.info("Time from MR submitted to MR started running By Topic:");
+    Map<String, Long> durations = getDurations(this.mrSubmitTimeByTopic, this.mrStartRunningTimeByTopic);
+    reportDurations(durations, maxToReport);
+  }
+
+  public void reportDurationFromMRStartedToMRFinished() {
+    this.reportDurationFromMRStartedToMRFinished(Integer.MAX_VALUE);
+  }
+
+  public void reportDurationFromMRStartedToMRFinished(int maxToReport) {
+    LOG.info("Time from MR started running to MR finished By Topic:");
+    Map<String, Long> durations = getDurations(this.mrStartRunningTimeByTopic, this.mrFinishTimeByTopic);
+    reportDurations(durations, maxToReport);
+  }
+
+  private void reportDurations(Map<String, Long> durations, int maxToReport) {
+    List<Map.Entry<String, Long>> durationsSorted = sortByValueDesc(durations);
+    for (int i = 0; i < durations.size() && i < maxToReport; i++) {
+      Map.Entry<String, Long> entry = durationsSorted.get(i);
+      LOG.info("  " + entry.getKey() + ": " + entry.getValue() / 1000L + " sec");
+    }
+  }
+
+  private Map<String, Long> getDurations(Map<String, Long> startTimes, Map<String, Long> endTimes) {
+    Map<String, Long> durations = new HashMap<String, Long>();
+    for (String topic : startTimes.keySet()) {
+      if (endTimes.containsKey(topic)) {
+        durations.put(topic, endTimes.get(topic) - startTimes.get(topic));
+      }
+    }
+    return durations;
+  }
+
+  private Map<String, Long> getDurations(long startTime, Map<String, Long> endTimes) {
+    Map<String, Long> durations = new HashMap<String, Long>();
+    for (String topic : endTimes.keySet()) {
+      durations.put(topic, endTimes.get(topic) - startTime);
+    }
+    return durations;
+  }
+
+  private static <K, V extends Comparable<? super V>> List<Map.Entry<K, V>> sortByValueDesc(Map<K, V> map) {
+    List<Map.Entry<K, V>> list = new LinkedList<Map.Entry<K, V>>(map.entrySet());
+    Collections.sort(list, new Comparator<Map.Entry<K, V>>() {
+      public int compare(Map.Entry<K, V> o1, Map.Entry<K, V> o2) {
+        return (o2.getValue()).compareTo(o1.getValue());
+      }
+    });
+    return list;
+  }
+}

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperMetrics.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperMetrics.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.log4j.Logger;
 
@@ -24,11 +25,11 @@ public class CamusSweeperMetrics {
   long timeStart;
 
   CamusSweeperMetrics() {
-    this.dataSizeByTopic = new HashMap<String, Long>();
-    this.mrSubmitTimeByTopic = new HashMap<String, Long>();
-    this.mrFinishTimeByTopic = new HashMap<String, Long>();
-    this.runnerStartTimeByTopic = new HashMap<String, Long>();
-    this.mrStartRunningTimeByTopic = new HashMap<String, Long>();
+    this.dataSizeByTopic = new ConcurrentHashMap<String, Long>();
+    this.mrSubmitTimeByTopic = new ConcurrentHashMap<String, Long>();
+    this.mrFinishTimeByTopic = new ConcurrentHashMap<String, Long>();
+    this.runnerStartTimeByTopic = new ConcurrentHashMap<String, Long>();
+    this.mrStartRunningTimeByTopic = new ConcurrentHashMap<String, Long>();
     timeStart = 0;
     totalDataSize = 0;
   }

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperPlanner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeperPlanner.java
@@ -1,20 +1,23 @@
 package com.linkedin.camus.sweeper;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
-import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 
 public abstract class CamusSweeperPlanner {
   protected Properties props;
-  protected Logger log;
+  protected Set<Properties> outlierProperties = new HashSet<Properties>();
+  private Logger log;
 
   public CamusSweeperPlanner setPropertiesLogger(Properties props, Logger log) {
     this.props = props;
@@ -24,6 +27,9 @@ public abstract class CamusSweeperPlanner {
 
   public abstract List<Properties> createSweeperJobProps(String topic, Path inputDir, Path outputDir, FileSystem fs)
       throws IOException;
+
+  protected abstract List<Properties> createSweeperJobProps(String topic, Path inputDir, Path outputDir, FileSystem fs,
+      CamusSweeperMetrics metrics) throws IOException;
 
   // Simple check for reprocessing depending on the modified time of the source and destination
   // folder
@@ -63,15 +69,21 @@ public abstract class CamusSweeperPlanner {
     return false;
   }
 
-  private class HiddenFilter implements PathFilter {
-    @Override
-    public boolean accept(Path path) {
-      String name = path.getName();
-      if (name.startsWith("_") || name.startsWith(".")) {
-        return false;
-      }
+  protected String pathListToCommaSeperated(List<Path> list) {
+    ArrayList<Path> tmpList = new ArrayList<Path>();
+    tmpList.addAll(list);
 
-      return true;
+    StringBuilder sb = new StringBuilder(tmpList.get(0).toString());
+    tmpList.remove(0);
+
+    for (Path p : tmpList) {
+      sb.append(",").append(p.toString());
     }
+
+    return sb.toString();
+  }
+
+  public Set<Properties> getOutlierProperties() {
+    return this.outlierProperties;
   }
 }

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/HiddenFilter.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/HiddenFilter.java
@@ -3,15 +3,14 @@ package com.linkedin.camus.sweeper;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 
+/**
+ * Filter a path if the path name starts with '_' or '.'
+ */
 public class HiddenFilter implements PathFilter {
   @Override
   public boolean accept(Path path) {
     String name = path.getName();
-    if (name.startsWith("_") || name.startsWith(".")) {
-      return false;
-    }
-
-    return true;
+    return !(name.startsWith("_") || name.startsWith("."));
   }
 }
 

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/HiddenFilter.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/HiddenFilter.java
@@ -1,0 +1,17 @@
+package com.linkedin.camus.sweeper;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+
+public class HiddenFilter implements PathFilter {
+  @Override
+  public boolean accept(Path path) {
+    String name = path.getName();
+    if (name.startsWith("_") || name.startsWith(".")) {
+      return false;
+    }
+
+    return true;
+  }
+}
+

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/mapreduce/CamusSweeperAvroKeyJob.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/mapreduce/CamusSweeperAvroKeyJob.java
@@ -77,14 +77,11 @@ public class CamusSweeperAvroKeyJob extends CamusSweeperJob {
       keySchema = RelaxedSchemaUtils.parseSchema(keySchemaStr, job.getConfiguration());
 
       keySchema = duplicateRecord(keySchema, schema);
-      log.info("key schema:" + keySchema);
 
       if (!validateKeySchema(schema, keySchema)) {
         log.info("topic:" + topic + " key invalid, using map only job");
         job.setNumReduceTasks(0);
         keySchema = schema;
-      } else {
-        log.info("topic:" + topic + " key is valid, deduping");
       }
     }
 
@@ -121,8 +118,6 @@ public class CamusSweeperAvroKeyJob extends CamusSweeperJob {
   }
 
   private void setupSchemas(String topic, Job job, Schema schema, Schema keySchema) {
-    log.info("Input Schema set to " + schema.toString());
-    log.info("Key Schema set to " + keySchema.toString());
     AvroJob.setInputKeySchema(job, schema);
 
     AvroJob.setMapOutputKeySchema(job, keySchema);
@@ -132,7 +127,6 @@ public class CamusSweeperAvroKeyJob extends CamusSweeperJob {
         RelaxedSchemaUtils.parseSchema(getConfValue(job, topic, "camus.output.schema", schema.toString()),
             job.getConfiguration());
     AvroJob.setOutputKeySchema(job, reducerSchema);
-    log.info("Output Schema set to " + reducerSchema.toString());
   }
 
   private Schema getNewestSchemaFromSource(Job job) throws IOException {

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/utils/DateUtils.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/utils/DateUtils.java
@@ -29,4 +29,9 @@ public class DateUtils {
     DateTime time = new DateTime(zone);
     return new DateTime(time.getYear(), time.getMonthOfYear(), time.getDayOfMonth(), 0, 0, 0, 0, zone);
   }
+
+  public DateTime getCurrentHour() {
+    DateTime time = new DateTime(zone);
+    return new DateTime(time.getYear(), time.getMonthOfYear(), time.getDayOfMonth(), time.getHourOfDay(), 0, 0, 0, zone);
+  }
 }

--- a/camus-sweeper/src/test/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlannerTest.java
+++ b/camus-sweeper/src/test/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlannerTest.java
@@ -10,7 +10,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Logger;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
 import org.junit.Test;
+
+import com.linkedin.camus.sweeper.utils.DateUtils;
 
 import static org.junit.Assert.*;
 
@@ -21,7 +25,10 @@ public class CamusHourlySweeperPlannerTest extends EasyMockSupport {
     FileSystem mockedFs = createMock(FileSystem.class);
     Path inputDir = new Path("inputDir");
     Path outputDir = new Path("outputDir");
-    String hour = "2015/04/01/12";
+    DateUtils dUtils = new DateUtils(new Properties());
+    DateTime currentHour = dUtils.getCurrentHour();
+    DateTimeFormatter hourFormatter = dUtils.getDateTimeFormatter("YYYY/MM/dd/HH");
+    String hour = currentHour.minusHours(1).toString(hourFormatter);
     Path inputDirWithHour = new Path(inputDir, hour);
     Path outputDirWithHour = new Path(outputDir, hour);
 

--- a/camus-sweeper/src/test/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlannerTest.java
+++ b/camus-sweeper/src/test/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlannerTest.java
@@ -1,0 +1,61 @@
+package com.linkedin.camus.sweeper;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.ContentSummary;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class CamusHourlySweeperPlannerTest extends EasyMockSupport {
+  @Test
+  public void testCreateSweeperJobProps() throws Exception {
+    FileSystem mockedFs = createMock(FileSystem.class);
+    Path inputDir = new Path("inputDir");
+    Path outputDir = new Path("outputDir");
+    String hour = "2015/04/01/12";
+    Path inputDirWithHour = new Path(inputDir, hour);
+    Path outputDirWithHour = new Path(outputDir, hour);
+
+    //inputDir should exist, but outputDir shouldn't.
+    EasyMock.expect(mockedFs.exists(inputDir)).andReturn(true).once();
+    EasyMock.expect(mockedFs.exists(outputDirWithHour)).andReturn(false).once();
+
+    FileStatus mockedFileStatus = createMock(FileStatus.class);
+    FileStatus[] fileStatuses = { mockedFileStatus };
+    EasyMock.expect(mockedFs.globStatus((Path) EasyMock.anyObject())).andReturn(fileStatuses).once();
+
+    EasyMock.expect(mockedFileStatus.getPath()).andReturn(inputDirWithHour).anyTimes();
+
+    ContentSummary mockedContentSummary = createMock(ContentSummary.class);
+    long dataSize = 100;
+    EasyMock.expect(mockedContentSummary.getLength()).andReturn(dataSize).once();
+    EasyMock.expect(mockedFs.getContentSummary(inputDirWithHour)).andReturn(mockedContentSummary).once();
+
+    replayAll();
+
+    String topic = "testTopic";
+
+    List<Properties> jobPropsList =
+        new CamusHourlySweeperPlanner().setPropertiesLogger(new Properties(), Logger.getLogger("testLogger"))
+            .createSweeperJobProps(topic, inputDir, outputDir, mockedFs);
+
+    assertEquals(1, jobPropsList.size());
+
+    Properties jobProps = jobPropsList.get(0);
+    String topicAndHour = topic + ":" + hour;
+
+    assertEquals(topic, jobProps.getProperty("topic"));
+    assertEquals(topicAndHour, jobProps.getProperty(CamusHourlySweeper.TOPIC_AND_HOUR));
+    assertEquals(inputDirWithHour.toString(), jobProps.getProperty(CamusHourlySweeper.INPUT_PATHS));
+    assertEquals(outputDirWithHour.toString(), jobProps.getProperty(CamusHourlySweeper.DEST_PATH));
+  }
+}


### PR DESCRIPTION
- Use current daily compaction approach for hourly compaction
- If outliers are detected, rather than reprocess the topic, simply add it to outlier folder
- Refactor the daily compaction code and remove unnecessary logging
- Report per-topic metrics for hourly compaction, such as data size, MR submit time, MR duration, etc.