### PR TITLE
Partial Fix for EOF/Coruption and Copy AND Data Loss issue 189

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ camus-api/target/
 camus-etl-kafka/target/
 camus-example/target/
 camus-schema-registry/target/
+
+release.properties
+pom.xml.versionsBackup
+pom.xml.releaseBackup

--- a/camus-api/pom.xml
+++ b/camus-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-api</artifactId>

--- a/camus-api/src/main/java/com/linkedin/camus/etl/RecordWriterProvider.java
+++ b/camus-api/src/main/java/com/linkedin/camus/etl/RecordWriterProvider.java
@@ -1,10 +1,11 @@
 package com.linkedin.camus.etl;
 
-import com.linkedin.camus.coders.CamusWrapper;
 import java.io.IOException;
-import org.apache.hadoop.mapreduce.RecordWriter;
+
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+
+import com.linkedin.camus.coders.CamusWrapper;
 
 /**
  *
@@ -14,7 +15,8 @@ public interface RecordWriterProvider {
 
     String getFilenameExtension();
 
-    RecordWriter<IEtlKey, CamusWrapper> getDataRecordWriter(
+    @SuppressWarnings("rawtypes")
+	RecordWriterWithCloseStatus<IEtlKey, CamusWrapper> getDataRecordWriter(
             TaskAttemptContext context, String fileName, CamusWrapper data, FileOutputCommitter committer) throws IOException,
             InterruptedException;
-}
+    }

--- a/camus-api/src/main/java/com/linkedin/camus/etl/RecordWriterWithCloseStatus.java
+++ b/camus-api/src/main/java/com/linkedin/camus/etl/RecordWriterWithCloseStatus.java
@@ -1,0 +1,19 @@
+package com.linkedin.camus.etl;
+
+import org.apache.hadoop.mapreduce.RecordWriter;
+
+
+/**
+ * This is writer interface added to check if underlying writer is closed or not. 
+ *
+ * @param <K>  key 
+ * @param <V>  value
+ */
+public abstract class RecordWriterWithCloseStatus<K, V> extends RecordWriter<K, V>{
+	/**
+	 * Give Ability to check if close has been called on the writer or File has been closed on not..
+	 * @return
+	 */
+	public abstract boolean isClose();
+	
+}

--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.linkedin.camus</groupId>
 		<artifactId>camus-parent</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>0.1.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camus-etl-kafka</artifactId>

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -1,16 +1,5 @@
 package com.linkedin.camus.etl.kafka;
 
-import com.linkedin.camus.etl.kafka.common.DateUtils;
-import com.linkedin.camus.etl.kafka.common.EtlCounts;
-import com.linkedin.camus.etl.kafka.common.EtlKey;
-import com.linkedin.camus.etl.kafka.common.ExceptionWritable;
-import com.linkedin.camus.etl.kafka.common.Source;
-import com.linkedin.camus.etl.kafka.mapred.EtlInputFormat;
-import com.linkedin.camus.etl.kafka.mapred.EtlMapper;
-import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
-import com.linkedin.camus.etl.kafka.mapred.EtlRecordReader;
-import com.linkedin.camus.etl.kafka.reporter.BaseReporter;
-import com.linkedin.camus.etl.kafka.reporter.TimeReporter;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -18,23 +7,16 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.ClassNotFoundException;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.Comparator;
-import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import org.apache.commons.cli.CommandLine;
@@ -55,7 +37,6 @@ import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.JobID;
 import org.apache.hadoop.mapred.TIPStatus;
 import org.apache.hadoop.mapred.TaskCompletionEvent;
 import org.apache.hadoop.mapred.TaskReport;
@@ -80,6 +61,16 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 
+import com.linkedin.camus.etl.kafka.common.DateUtils;
+import com.linkedin.camus.etl.kafka.common.EtlCounts;
+import com.linkedin.camus.etl.kafka.common.EtlKey;
+import com.linkedin.camus.etl.kafka.common.ExceptionWritable;
+import com.linkedin.camus.etl.kafka.common.Source;
+import com.linkedin.camus.etl.kafka.mapred.EtlInputFormat;
+import com.linkedin.camus.etl.kafka.mapred.EtlMapper;
+import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
+import com.linkedin.camus.etl.kafka.mapred.EtlRecordReader;
+import com.linkedin.camus.etl.kafka.reporter.BaseReporter;
 
 public class CamusJob extends Configured implements Tool {
 
@@ -119,7 +110,6 @@ public class CamusJob extends Configured implements Tool {
   private Job hadoopJob = null;
 
   private final Properties props;
-
   private DateTimeFormatter dateFmt = DateUtils.getDateTimeFormatter("YYYY-MM-dd-HH-mm-ss", DateTimeZone.UTC);
 
   public CamusJob() throws IOException {
@@ -132,7 +122,7 @@ public class CamusJob extends Configured implements Tool {
 
   public CamusJob(Properties props, Logger log) throws IOException {
     this.props = props;
-    this.log = log;
+    CamusJob.log = log;
   }
 
   private static HashMap<String, Long> timingMap = new HashMap<String, Long>();
@@ -203,7 +193,6 @@ public class CamusJob extends Configured implements Tool {
                 break;
               }
             }
-
             if (!filterMatch)
               DistributedCache.addFileToClassPath(status[i].getPath(), conf, fs);
           }
@@ -424,11 +413,6 @@ public class CamusJob extends Configured implements Tool {
     if (EtlInputFormat.reportJobFailureUnableToGetOffsetFromKafka) {
       EtlInputFormat.reportJobFailureUnableToGetOffsetFromKafka = false;
       throw new RuntimeException("Some topics skipped due to failure in getting latest offset from Kafka leaders.");
-    }
-
-    if (EtlInputFormat.reportJobFailureDueToLeaderNotAvailable) {
-      EtlInputFormat.reportJobFailureDueToLeaderNotAvailable = false;
-      throw new RuntimeException("Some topic partitions skipped due to Kafka leader not available.");
     }
   }
 

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/AvroRecordWriterProvider.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/AvroRecordWriterProvider.java
@@ -1,19 +1,23 @@
 package com.linkedin.camus.etl.kafka.common;
 
-import com.linkedin.camus.coders.CamusWrapper;
-import com.linkedin.camus.etl.IEtlKey;
-import com.linkedin.camus.etl.RecordWriterProvider;
-import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
 import java.io.IOException;
+
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.etl.IEtlKey;
+import com.linkedin.camus.etl.RecordWriterProvider;
+import com.linkedin.camus.etl.RecordWriterWithCloseStatus;
+import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
+
+import org.apache.log4j.Logger;
 
 
 /**
@@ -21,47 +25,79 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
  *
  */
 public class AvroRecordWriterProvider implements RecordWriterProvider {
-  public final static String EXT = ".avro";
+    public final static String EXT = ".avro";
+    
+    private static Logger log = Logger.getLogger(AvroRecordWriterProvider.class);
+    
 
-  public AvroRecordWriterProvider(TaskAttemptContext context) {
-  }
-
-  @Override
-  public String getFilenameExtension() {
-    return EXT;
-  }
-
-  @Override
-  public RecordWriter<IEtlKey, CamusWrapper> getDataRecordWriter(TaskAttemptContext context, String fileName,
-      CamusWrapper data, FileOutputCommitter committer) throws IOException, InterruptedException {
-    final DataFileWriter<Object> writer = new DataFileWriter<Object>(new SpecificDatumWriter<Object>());
-
-    if (FileOutputFormat.getCompressOutput(context)) {
-      if ("snappy".equals(EtlMultiOutputFormat.getEtlOutputCodec(context))) {
-        writer.setCodec(CodecFactory.snappyCodec());
-      } else {
-        int level = EtlMultiOutputFormat.getEtlDeflateLevel(context);
-        writer.setCodec(CodecFactory.deflateCodec(level));
-      }
+    public AvroRecordWriterProvider(TaskAttemptContext context) {
+    }
+    
+    @Override
+    public String getFilenameExtension() {
+        return EXT;
     }
 
-    Path path = committer.getWorkPath();
-    path = new Path(path, EtlMultiOutputFormat.getUniqueFile(context, fileName, EXT));
-    writer.create(((GenericRecord) data.getRecord()).getSchema(), path.getFileSystem(context.getConfiguration())
-        .create(path));
+    @SuppressWarnings("rawtypes")
+	@Override
+    public RecordWriterWithCloseStatus<IEtlKey, CamusWrapper> getDataRecordWriter(
+            TaskAttemptContext context,
+            String fileName,
+            CamusWrapper data,
+            FileOutputCommitter committer) throws IOException, InterruptedException {
+        final DataFileWriter<Object> writer = new DataFileWriter<Object>(
+                new SpecificDatumWriter<Object>());
 
-    writer.setSyncInterval(EtlMultiOutputFormat.getEtlAvroWriterSyncInterval(context));
+        if (FileOutputFormat.getCompressOutput(context)) {
+            if ("snappy".equals(EtlMultiOutputFormat.getEtlOutputCodec(context))) {
+                writer.setCodec(CodecFactory.snappyCodec());
+            } else {
+                int level = EtlMultiOutputFormat.getEtlDeflateLevel(context);
+                writer.setCodec(CodecFactory.deflateCodec(level));
+            }
+        }
 
-    return new RecordWriter<IEtlKey, CamusWrapper>() {
-      @Override
-      public void write(IEtlKey ignore, CamusWrapper data) throws IOException {
-        writer.append(data.getRecord());
-      }
+        Path path = committer.getWorkPath();
+        path = new Path(path, EtlMultiOutputFormat.getUniqueFile(context, fileName, EXT));
+        writer.create(((GenericRecord) data.getRecord()).getSchema(),
+                path.getFileSystem(context.getConfiguration()).create(path));
 
-      @Override
-      public void close(TaskAttemptContext arg0) throws IOException, InterruptedException {
-        writer.close();
-      }
-    };
-  }
+        writer.setSyncInterval(EtlMultiOutputFormat.getEtlAvroWriterSyncInterval(context));
+
+        return new RecordWriterWithCloseStatus<IEtlKey, CamusWrapper>() {
+        	
+        	private volatile boolean close;
+            @Override
+            public void write(IEtlKey ignore, CamusWrapper data) throws IOException {
+                writer.append(data.getRecord());
+            }
+
+            @Override
+            public void close(TaskAttemptContext arg0) throws IOException, InterruptedException {
+                writer.close();
+                close = true;
+            }
+            
+            /**
+             * THis is our last attemp to close the file...
+             */
+            @Override
+            protected void finalize() throws Throwable {
+            	if(!this.close){
+            		log.error("This file was not closed so try to close during the JVM finalize..");
+            		try{
+            			writer.close();
+            		}catch(Throwable th){
+            			log.error("File Close erorr during finalize()");
+            		}
+            	}
+            	super.finalize();
+            }
+            
+            @Override
+            public boolean isClose() {
+				return close;
+			}
+        };
+    }
 }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlCounts.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlCounts.java
@@ -206,7 +206,7 @@ public class EtlCounts {
       encoder.init(props, "TrackingMonitoringEvent");
       monitoringDetails =
           (AbstractMonitoringEvent) Class.forName(getMonitoringEventClass(conf))
-              .getDeclaredConstructor(Configuration.class).newInstance(conf);
+          .getDeclaredConstructor(Configuration.class).newInstance(conf);
     } catch (Exception e1) {
       throw new RuntimeException(e1);
     }
@@ -250,10 +250,9 @@ public class EtlCounts {
     props.put("request.timeout.ms", "30000");
     log.debug("Broker list: " + brokerList);
 
-    Producer producer = null;
+    Producer producer = createProducer(props);
 
     try {
-      producer = createProducer(props);
       for (byte[] message : monitorSet) {
         for (int i = 0; i < NUM_TRIES_PUBLISH_COUNTS; i++) {
           try {
@@ -264,11 +263,11 @@ public class EtlCounts {
             log.error("Publishing count for topic " + topic + " to " + brokerList.toString() + " has failed " + (i + 1)
                 + " times. " + (NUM_TRIES_PUBLISH_COUNTS - i - 1) + " more attempts will be made.");
             if (i == NUM_TRIES_PUBLISH_COUNTS - 1) {
-              throw new RuntimeException(e.getMessage() + ": " + "Have retried maximum (" + NUM_TRIES_PUBLISH_COUNTS
-                  + ") times.");
+              throw new RuntimeException(e.getMessage() + ": " + "Have retried maximum ("
+                  + NUM_TRIES_PUBLISH_COUNTS + ") times.");
             }
             try {
-              Thread.sleep((long) (Math.random() * (i + 1) * 1000));
+              Thread.sleep((long)(Math.random() * (i + 1) * 1000));
             } catch (InterruptedException e1) {
               log.error("Caught interrupted exception between retries of publishing counts to Kafka. "
                   + e1.getMessage());
@@ -276,8 +275,6 @@ public class EtlCounts {
           }
         }
       }
-    } catch (Exception e) {
-      throw new RuntimeException("failed to publish counts to kafka: " + e.getMessage(), e);
     } finally {
       if (producer != null) {
         producer.close();

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/SequenceFileRecordWriterProvider.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/SequenceFileRecordWriterProvider.java
@@ -1,28 +1,26 @@
 package com.linkedin.camus.etl.kafka.common;
 
-import com.linkedin.camus.coders.CamusWrapper;
-import com.linkedin.camus.etl.IEtlKey;
-import com.linkedin.camus.etl.RecordWriterProvider;
-import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
 import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.util.ReflectionUtils;
-import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.SequenceFile.CompressionType;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
 import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
-
-import org.apache.hadoop.io.SequenceFile;
-import org.apache.hadoop.io.SequenceFile.CompressionType;
-import org.apache.hadoop.io.compress.DefaultCodec;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.LongWritable;
-import org.apache.hadoop.io.Text;
-
-import org.apache.hadoop.conf.Configuration;
-
+import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.log4j.Logger;
 
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.etl.IEtlKey;
+import com.linkedin.camus.etl.RecordWriterProvider;
+import com.linkedin.camus.etl.RecordWriterWithCloseStatus;
+import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
 
 /**
  * Provides a RecordWriter that uses SequenceFile.Writer to write
@@ -35,72 +33,103 @@ import org.apache.log4j.Logger;
  *
  */
 public class SequenceFileRecordWriterProvider implements RecordWriterProvider {
-  public static final String ETL_OUTPUT_RECORD_DELIMITER = "etl.output.record.delimiter";
-  public static final String DEFAULT_RECORD_DELIMITER = "";
+    public static final String ETL_OUTPUT_RECORD_DELIMITER = "etl.output.record.delimiter";
+    public static final String DEFAULT_RECORD_DELIMITER = "";
 
-  private static Logger log = Logger.getLogger(SequenceFileRecordWriterProvider.class);
+    private static Logger log = Logger.getLogger(SequenceFileRecordWriterProvider.class);
 
-  protected String recordDelimiter = null;
-
-  public SequenceFileRecordWriterProvider(TaskAttemptContext context) {
-
-  }
-
-  // TODO: Make this configurable somehow.
-  // To do this, we'd have to make SequenceFileRecordWriterProvider have an
-  // init(JobContext context) method signature that EtlMultiOutputFormat would always call.
-  @Override
-  public String getFilenameExtension() {
-    return "";
-  }
-
-  @Override
-  public RecordWriter<IEtlKey, CamusWrapper> getDataRecordWriter(TaskAttemptContext context, String fileName,
-      CamusWrapper camusWrapper, FileOutputCommitter committer) throws IOException, InterruptedException {
-
-    Configuration conf = context.getConfiguration();
-
-    // If recordDelimiter hasn't been initialized, do so now
-    if (recordDelimiter == null) {
-      recordDelimiter = conf.get(ETL_OUTPUT_RECORD_DELIMITER, DEFAULT_RECORD_DELIMITER);
+    protected String recordDelimiter = null;
+        
+    public SequenceFileRecordWriterProvider(TaskAttemptContext  context) {
+    	
     }
 
-    CompressionCodec compressionCodec = null;
-    CompressionType compressionType = CompressionType.NONE;
-
-    // Determine compression type (BLOCK or RECORD) and compression codec to use.
-    if (SequenceFileOutputFormat.getCompressOutput(context)) {
-      compressionType = SequenceFileOutputFormat.getOutputCompressionType(context);
-      Class<?> codecClass = SequenceFileOutputFormat.getOutputCompressorClass(context, DefaultCodec.class);
-      // Instantiate the CompressionCodec Class
-      compressionCodec = (CompressionCodec) ReflectionUtils.newInstance(codecClass, conf);
+    // TODO: Make this configurable somehow.
+    // To do this, we'd have to make SequenceFileRecordWriterProvider have an
+    // init(JobContext context) method signature that EtlMultiOutputFormat would always call.
+    @Override
+    public String getFilenameExtension() {
+        return "";
     }
 
-    // Get the filename for this RecordWriter.
-    Path path =
-        new Path(committer.getWorkPath(), EtlMultiOutputFormat.getUniqueFile(context, fileName, getFilenameExtension()));
+    @SuppressWarnings("rawtypes")
+    @Override
+    public RecordWriterWithCloseStatus<IEtlKey, CamusWrapper> getDataRecordWriter(TaskAttemptContext context, String fileName,
+        CamusWrapper camusWrapper, FileOutputCommitter committer) throws IOException, InterruptedException {
 
-    log.info("Creating new SequenceFile.Writer with compression type " + compressionType + " and compression codec "
-        + (compressionCodec != null ? compressionCodec.getClass().getName() : "null"));
-    final SequenceFile.Writer writer =
-        SequenceFile.createWriter(path.getFileSystem(conf), conf, path, LongWritable.class, Text.class,
-            compressionType, compressionCodec, context);
+      Configuration conf = context.getConfiguration();
 
-    // Return a new anonymous RecordWriter that uses the
-    // SequenceFile.Writer to write data to HDFS
-    return new RecordWriter<IEtlKey, CamusWrapper>() {
-      @Override
-      public void write(IEtlKey key, CamusWrapper data) throws IOException, InterruptedException {
-        String record = (String) data.getRecord() + recordDelimiter;
-        // Use the timestamp from the EtlKey as the key for this record.
-        // TODO: Is there a better key to use here?
-        writer.append(new LongWritable(key.getTime()), new Text(record));
+      // If recordDelimiter hasn't been initialized, do so now
+      if (recordDelimiter == null) {
+        recordDelimiter = conf.get(ETL_OUTPUT_RECORD_DELIMITER, DEFAULT_RECORD_DELIMITER);
       }
 
-      @Override
-      public void close(TaskAttemptContext context) throws IOException, InterruptedException {
-        writer.close();
+      CompressionCodec compressionCodec = null;
+      CompressionType compressionType = CompressionType.NONE;
+
+      // Determine compression type (BLOCK or RECORD) and compression codec to use.
+      if (SequenceFileOutputFormat.getCompressOutput(context)) {
+        compressionType = SequenceFileOutputFormat.getOutputCompressionType(context);
+        Class<?> codecClass = SequenceFileOutputFormat.getOutputCompressorClass(context, DefaultCodec.class);
+        // Instantiate the CompressionCodec Class
+        compressionCodec = (CompressionCodec) ReflectionUtils.newInstance(codecClass, conf);
       }
-    };
-  }
+
+      // Get the filename for this RecordWriter.
+      Path path =
+          new Path(committer.getWorkPath(), EtlMultiOutputFormat.getUniqueFile(context, fileName, getFilenameExtension()));
+
+      log.info("Creating new SequenceFile.Writer with compression type " + compressionType + " and compression codec "
+          + (compressionCodec != null ? compressionCodec.getClass().getName() : "null"));
+      final SequenceFile.Writer writer =
+          SequenceFile.createWriter(path.getFileSystem(conf), conf, path, LongWritable.class, Text.class,
+              compressionType, compressionCodec, context);
+        // Return a new anonymous RecordWriter that uses the
+        // SequenceFile.Writer to write data to HDFS
+        return new RecordWriterWithCloseStatus<IEtlKey, CamusWrapper>() {
+            private volatile boolean close;
+
+            @Override
+            public void write(IEtlKey key, CamusWrapper data) throws IOException, InterruptedException {
+            	
+            	String record = (String)data.getRecord();
+            	// do not do string concatenate if not needed...here...???
+            	if(recordDelimiter != null && !recordDelimiter.isEmpty()){
+            		record = record + recordDelimiter;
+            	}
+            	
+            	/**
+            	 * What if file is closed ?  Should we create a new one here..?
+            	 * should we reopen it or not...
+            	 */        	
+                // Use the timestamp from the EtlKey as the key for this record.
+                // TODO: Is there a better key to use here?
+                writer.append(new LongWritable(key.getTime()), new Text(record));
+            }
+
+            @Override
+            public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+                writer.close();
+                close = true;
+            }
+            @Override
+            protected void finalize() throws Throwable {
+            	if(!this.close){
+            		log.error("This file was not closed so try to close during the JVM finalize..");
+            		try{
+            			writer.close();
+            		}catch(Throwable th){
+            			log.error("File Close erorr during finalize()");
+            		}
+            	}
+            	super.finalize();
+            }
+
+			@Override
+			public boolean isClose() {
+				return close;
+			}            
+        };
+    }
+    
 }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -1,16 +1,5 @@
 package com.linkedin.camus.etl.kafka.mapred;
 
-import com.linkedin.camus.coders.CamusWrapper;
-import com.linkedin.camus.coders.MessageDecoder;
-import com.linkedin.camus.etl.kafka.CamusJob;
-import com.linkedin.camus.etl.kafka.coders.KafkaAvroMessageDecoder;
-import com.linkedin.camus.etl.kafka.coders.MessageDecoderFactory;
-import com.linkedin.camus.etl.kafka.common.EtlKey;
-import com.linkedin.camus.etl.kafka.common.EtlRequest;
-import com.linkedin.camus.etl.kafka.common.LeaderInfo;
-import com.linkedin.camus.workallocater.CamusRequest;
-import com.linkedin.camus.workallocater.WorkAllocator;
-
 import java.io.IOException;
 import java.net.URI;
 import java.security.InvalidParameterException;
@@ -25,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import kafka.api.PartitionOffsetRequestInfo;
@@ -69,6 +57,7 @@ import com.linkedin.camus.workallocater.WorkAllocator;
 /**
  * Input format for a Kafka pull job.
  */
+@SuppressWarnings("rawtypes")
 public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 
   public static final String KAFKA_BLACKLIST_TOPIC = "kafka.blacklist.topics";
@@ -99,7 +88,6 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
 
   public static boolean reportJobFailureDueToOffsetOutOfRange = false;
   public static boolean reportJobFailureUnableToGetOffsetFromKafka = false;
-  public static boolean reportJobFailureDueToLeaderNotAvailable = false;
 
   private static Logger log = null;
 
@@ -349,7 +337,6 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
               log.info("Skipping the creation of ETL request for Topic : " + topicMetadata.topic()
                   + " and Partition : " + partitionMetadata.partitionId() + " Exception : "
                   + ErrorMapping.exceptionFor(partitionMetadata.errorCode()));
-              reportJobFailureDueToLeaderNotAvailable = true; 
             } else {
               if (partitionMetadata.errorCode() != ErrorMapping.NoError()) {
                 log.warn("Receiving non-fatal error code, Continuing the creation of ETL request for Topic : "

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputRecordWriter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputRecordWriter.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -20,10 +22,11 @@ import org.joda.time.DateTime;
 import com.linkedin.camus.coders.CamusWrapper;
 import com.linkedin.camus.etl.IEtlKey;
 import com.linkedin.camus.etl.RecordWriterProvider;
+import com.linkedin.camus.etl.RecordWriterWithCloseStatus;
 import com.linkedin.camus.etl.kafka.common.EtlKey;
 import com.linkedin.camus.etl.kafka.common.ExceptionWritable;
 
-
+@SuppressWarnings("rawtypes")
 public class EtlMultiOutputRecordWriter extends RecordWriter<EtlKey, Object> {
   private TaskAttemptContext context;
   private Writer errorWriter = null;
@@ -32,8 +35,9 @@ public class EtlMultiOutputRecordWriter extends RecordWriter<EtlKey, Object> {
   private static Logger log = Logger.getLogger(EtlMultiOutputRecordWriter.class);
   private final Counter topicSkipOldCounter;
 
-  private HashMap<String, RecordWriter<IEtlKey, CamusWrapper>> dataWriters =
-      new HashMap<String, RecordWriter<IEtlKey, CamusWrapper>>();
+
+  private HashMap<String, RecordWriterWithCloseStatus<IEtlKey, CamusWrapper>> dataWriters =
+      new HashMap<String, RecordWriterWithCloseStatus<IEtlKey, CamusWrapper>>();
 
   private EtlMultiOutputCommitter committer;
 
@@ -82,10 +86,57 @@ public class EtlMultiOutputRecordWriter extends RecordWriter<EtlKey, Object> {
 
   @Override
   public void close(TaskAttemptContext context) throws IOException, InterruptedException {
-    for (String w : dataWriters.keySet()) {
-      dataWriters.get(w).close(context);
-    }
-    errorWriter.close();
+		// this is another soruce of unclosed files
+		ListOfIOException listExp = new ListOfIOException(
+				"List Of IOException while closing output file...");
+		for (String w : dataWriters.keySet()) {
+			try {
+				RecordWriterWithCloseStatus writter = dataWriters.get(w);
+				writter.close(context);
+				if(!writter.isClose()){
+					log.error("Atteptem to close the file name "+ w +" but it did not close.");
+				}
+			} catch (IOException exp) {
+				log.error("Error closing writer..", exp);
+				listExp.addIOException(exp);
+			}
+		}
+
+		try {
+			errorWriter.close();
+		} catch (IOException e) {
+			listExp.addIOException(e);
+		}
+		
+		if(listExp.isThereException()){
+			throw listExp;
+		}
+		
+  }
+  
+  static final class ListOfIOException extends IOException {
+	
+	private static final long serialVersionUID = 1L;
+	private List<IOException> exceptionList = new ArrayList<IOException>();
+	
+	ListOfIOException(String message) {
+		super(message);
+	}
+	
+	public void addIOException(IOException exp){
+		exceptionList.add(exp);
+	}
+	
+	public boolean isThereException(){
+		return !exceptionList.isEmpty();
+	}
+	
+	@Override
+	public String toString() {
+		// TODO should we print all the IOEceptions....
+		return super.toString() + " There were about "+  exceptionList.size() + " IOException. please check the logs for this task";
+	}
+	
   }
 
   @Override
@@ -99,13 +150,30 @@ public class EtlMultiOutputRecordWriter extends RecordWriter<EtlKey, Object> {
         committer.addOffset(key);
       } else {
         if (!key.getTopic().equals(currentTopic)) {
-          for (RecordWriter<IEtlKey, CamusWrapper> writer : dataWriters.values()) {
-            writer.close(context);
-          }
+    	
+           // this is another soruce of unclosed files
+           ListOfIOException listExp = new ListOfIOException(
+    				"List Of IOException while closing output file...");
+          
+   		for (String w : dataWriters.keySet()) {
+			try {
+				RecordWriterWithCloseStatus writter = dataWriters.get(w);
+				writter.close(context);
+				if(!writter.isClose()){
+					log.error("Atteptem to close the file name "+ w +" but it did not close.");
+					throw new IOException("Unclosed File Detected ! File Name ="+w + " File_Writer"+ writter.toString());
+				}
+			} catch (IOException exp) {
+				log.error("Error closing writer..", exp);
+				listExp.addIOException(exp);
+			}
+		}
           dataWriters.clear();
           currentTopic = key.getTopic();
+          if(listExp.isThereException()){
+        	  throw listExp;
+          }
         }
-
         committer.addCounts(key);
         CamusWrapper value = (CamusWrapper) val;
         String workingFileName = EtlMultiOutputFormat.getWorkingFileName(context, key);
@@ -124,21 +192,25 @@ public class EtlMultiOutputRecordWriter extends RecordWriter<EtlKey, Object> {
     }
   }
 
-  private RecordWriter<IEtlKey, CamusWrapper> getDataRecordWriter(TaskAttemptContext context, String fileName,
-      CamusWrapper value) throws IOException, InterruptedException {
-    RecordWriterProvider recordWriterProvider = null;
-    try {
-      //recordWriterProvider = EtlMultiOutputFormat.getRecordWriterProviderClass(context).newInstance();
-      Class<RecordWriterProvider> rwp = EtlMultiOutputFormat.getRecordWriterProviderClass(context);
-      Constructor<RecordWriterProvider> crwp = rwp.getConstructor(TaskAttemptContext.class);
-      recordWriterProvider = crwp.newInstance(context);
-    } catch (InstantiationException e) {
-      throw new IllegalStateException(e);
-    } catch (IllegalAccessException e) {
-      throw new IllegalStateException(e);
-    } catch (Exception e) {
-      throw new IllegalStateException(e);
-    }
-    return recordWriterProvider.getDataRecordWriter(context, fileName, value, committer);
-  }
+  private RecordWriterWithCloseStatus<IEtlKey, CamusWrapper> getDataRecordWriter(
+			TaskAttemptContext context, String fileName, CamusWrapper value)
+			throws IOException, InterruptedException {
+		RecordWriterProvider recordWriterProvider = null;
+		try {
+			Class<RecordWriterProvider> rwp = EtlMultiOutputFormat
+					.getRecordWriterProviderClass(context);
+			Constructor<RecordWriterProvider> crwp = rwp
+					.getConstructor(TaskAttemptContext.class);
+			recordWriterProvider = crwp.newInstance(context);
+		} catch (InstantiationException e) {
+			throw new IllegalStateException(e);
+		} catch (IllegalAccessException e) {
+			throw new IllegalStateException(e);
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+		return recordWriterProvider.getDataRecordWriter(context, fileName,
+				value, committer);
+	}
+
 }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/BaseReporter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/BaseReporter.java
@@ -1,8 +1,7 @@
 package com.linkedin.camus.etl.kafka.reporter;
 
-import java.util.Map;
 import java.io.IOException;
-import org.apache.log4j.Logger;
+import java.util.Map;
 
 import org.apache.hadoop.mapreduce.Job;
 
@@ -11,7 +10,7 @@ public abstract class BaseReporter {
   public static org.apache.log4j.Logger log;
 
   public BaseReporter() {
-    this.log = org.apache.log4j.Logger.getLogger(BaseReporter.class);
+    log = org.apache.log4j.Logger.getLogger(BaseReporter.class);
   }
 
   public abstract void report(Job job, Map<String, Long> timingMap) throws IOException;

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
@@ -1,16 +1,15 @@
 package com.linkedin.camus.etl.kafka.reporter;
 
-import com.timgroup.statsd.StatsDClient;
-import com.timgroup.statsd.NonBlockingStatsDClient;
-import java.util.Map;
 import java.io.IOException;
-import org.apache.hadoop.mapreduce.Job;
-import org.apache.hadoop.mapreduce.Counter;
-import org.apache.hadoop.mapreduce.Counters;
-import org.apache.hadoop.mapreduce.CounterGroup;
-import org.apache.hadoop.util.ToolRunner;
+import java.util.Map;
 
-import com.linkedin.camus.etl.kafka.reporter.TimeReporter;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.hadoop.mapreduce.CounterGroup;
+import org.apache.hadoop.mapreduce.Counters;
+import org.apache.hadoop.mapreduce.Job;
+
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClient;
 
 
 public class StatsdReporter extends TimeReporter {

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/RetryCheckDecorator.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/RetryCheckDecorator.java
@@ -1,0 +1,24 @@
+package com.linkedin.camus.etl.kafka.utils;
+
+public class RetryCheckDecorator<T> implements RetryLogic.Delegate<T>{
+
+	private int counter = 0;
+	private RetryLogic.Delegate<T> target;
+
+	public RetryCheckDecorator(RetryLogic.Delegate<T> target){
+		if(target == null){
+			throw new NullPointerException("Target Invocation Object cannot be null");
+		}
+		this.target = target;
+	}
+	
+	@Override
+	public T call() throws Exception {
+		counter++;
+		return target.call();
+	}
+	
+	public int invokeCount(){
+		return counter;
+	}
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/RetryExhausted.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/RetryExhausted.java
@@ -1,0 +1,26 @@
+package com.linkedin.camus.etl.kafka.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RetryExhausted extends Exception{
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 5120068860833652540L;
+	
+	private transient List<Throwable> listofThrowables = new ArrayList<Throwable>();
+	
+	public RetryExhausted(String message) {
+	}
+	
+	public void addException(Throwable th){
+		listofThrowables.add(th);
+	}
+	
+	public boolean hasException(){
+		return !listofThrowables.isEmpty();
+	}
+	
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/RetryLogic.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/RetryLogic.java
@@ -1,0 +1,90 @@
+package com.linkedin.camus.etl.kafka.utils;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.log4j.Logger;
+
+/**
+ * http://stackoverflow.com/questions/9539845/java-how-to-handle-retries-without-copy-paste-code
+ * 
+ * Generic Retry with Any exception try again and again.
+ * 
+ */
+public class RetryLogic<T> {
+	
+	public static interface Delegate<T> {
+		T call() throws Exception;
+	}
+   
+	private static final Logger logger = Logger.getLogger(RetryLogic.class);
+	
+	private int maxAttempts;
+	private long retryWaitInMs;
+	private T expectedResult;
+
+	public RetryLogic(int maxAttempts, long retryWait,TimeUnit timeUnit, T expectedResult) {
+		this.maxAttempts = maxAttempts;
+		if(TimeUnit.MILLISECONDS != timeUnit){
+			this.retryWaitInMs = timeUnit.toMillis(retryWait);
+		}else{
+			this.retryWaitInMs = retryWait;
+		}
+		this.expectedResult = expectedResult;
+	}
+
+	public T getResultWithRetry(Delegate<T> caller) throws RetryExhausted {
+		T result = null;
+		int remainingAttempts = maxAttempts;
+		RetryExhausted retryExcep = new RetryExhausted(caller.getClass() + " Failed After " + maxAttempts + " retry.");
+		while(true){
+			try {
+				remainingAttempts--;
+				result = caller.call();
+				// covers the null case....
+				if(result == expectedResult){
+					return result;
+				// is what you expect result to be...
+				}else if(expectedResult != null && expectedResult.equals(result)){
+					return result;
+				}else if(  (expectedResult == null && result != null) || (expectedResult != null && !expectedResult.equals(result))){
+					// retry when except result does not match up...
+					logger.warn("WARN Retrying again because expected result does not match actual result after calling so wait for retryWaitInMs="+retryWaitInMs +" retryLeft="+remainingAttempts);
+				}else{
+					String msg = "Expected and result condition missing expectedResult=" + (expectedResult == null?"null":expectedResult.toString()) +" result="+(result == null?"null":result.toString()); 
+					logger.warn(msg);
+					throw new RuntimeException(msg);
+				}
+			}catch (Throwable e) {
+				// what should be do if we get interupt signal...
+				if(e instanceof InterruptedException){
+					logger.warn("Thread="+Thread.currentThread().getName() +" was interupted while retry...so exiting passing on the signal...");
+					Thread.interrupted();
+				}else{
+					logger.warn("WARN Retrying again due to fatal erorr",e);
+					retryExcep.addException(e);
+				}
+			}			
+			if (remainingAttempts <= 0) {
+				if(!retryExcep.hasException()){
+					logger.warn("Could not get expected result after "+maxAttempts+ " attempt(s) ");
+					//return last...
+					return result;
+				}else{				
+					logger.error("ERROR cannot recover from the fatal error after " +maxAttempts+ " attempt(s) hasException="+retryExcep.hasException());
+					throw retryExcep;
+				}
+			} else {
+				// else retry immediately 
+				if(retryWaitInMs > 0){
+					try {
+						Thread.sleep(retryWaitInMs);
+					} catch (InterruptedException ie) {
+						logger.error("while we are waiting this thread was interupted...so passing on the interupt..");
+						Thread.interrupted();
+					}
+				}
+			}
+		}
+	}
+	
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/DirDeleteTask.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/DirDeleteTask.java
@@ -1,0 +1,39 @@
+package com.linkedin.camus.etl.kafka.utils.io;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+import com.linkedin.camus.etl.kafka.utils.RetryLogic;
+
+public class DirDeleteTask implements RetryLogic.Delegate<Boolean> {
+
+	private static final Logger log = Logger.getLogger(DirDeleteTask.class);
+
+	
+	private FileSystem fs;
+	private Path path;
+	
+	DirDeleteTask(FileSystem fs,Path path ){
+		if(fs == null || path == null){
+			throw new NullPointerException("FileSystem object fs or Path path cannot be null!");
+		} 
+		this.fs = fs ;
+		this.path = path;
+	}
+	
+	@Override
+	public Boolean call() throws Exception {		
+		boolean result = false;
+		boolean dirExists = fs.exists(path);
+		if(dirExists){
+			log.info("Path :" + path.toString() + "is marked for deletion.");
+			result = fs.delete(path, true);
+		}else {
+			// file does not exits delete it..
+			result = true;
+		}
+		return result;
+	}
+
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileCommitUtil.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileCommitUtil.java
@@ -20,11 +20,11 @@ import com.linkedin.camus.etl.kafka.utils.RetryExhausted;
 import com.linkedin.camus.etl.kafka.utils.RetryLogic;
 
 /**
- * Custom code to commit the file across volumes as suggested by the Peter Newcomb...
+ * 
  *  We also wanted to preserve the so we need attempted task id as well... hence this will be only called when task that is needs to be committed.
  *  mapred.map.tasks.speculative.execution	true	If true, then multiple instances of some map tasks may be executed in parallel for safe reason add "taskid to temp"
  * 
- *  user volume/tmp  (volume 1)  to /raw/logmon (volume 2) and then rename file to final target location (/raw/logmon/...)
+ *  user volume/tmp  (volume 1)  to /raw/log (volume 2) and then rename file to final target location (/raw/log/...)
  *  can not remove /_temporary as other camus job may write to it so delete it till taskid.
  *  
  *  This is very inefficient solution (Kakfa ->copy to temp user volume-> copy to temp day volume ->rename to final destination.

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileCommitUtil.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileCommitUtil.java
@@ -1,0 +1,200 @@
+package com.linkedin.camus.etl.kafka.utils.io;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.StatusReporter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.log4j.Logger;
+
+import com.linkedin.camus.etl.kafka.CamusJob;
+import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
+import com.linkedin.camus.etl.kafka.utils.RetryExhausted;
+import com.linkedin.camus.etl.kafka.utils.RetryLogic;
+
+/**
+ * Custom code to commit the file across volumes as suggested by the Peter Newcomb...
+ *  We also wanted to preserve the so we need attempted task id as well... hence this will be only called when task that is needs to be committed.
+ *  mapred.map.tasks.speculative.execution	true	If true, then multiple instances of some map tasks may be executed in parallel for safe reason add "taskid to temp"
+ * 
+ *  user volume/tmp  (volume 1)  to /raw/logmon (volume 2) and then rename file to final target location (/raw/logmon/...)
+ *  can not remove /_temporary as other camus job may write to it so delete it till taskid.
+ *  
+ *  This is very inefficient solution (Kakfa ->copy to temp user volume-> copy to temp day volume ->rename to final destination.
+ *  This will increase the latency of Camus job, Hence, lags is expected to go high.
+ *  
+ */
+public final class FileCommitUtil {
+
+	//TODO have this configurable 
+	private static final int MAX_RETRY = 3;
+	private static final int WAIT_SECONDS = 1;
+	
+	public static void commitWithCopyAndRenameFile(final JobContext job,
+			final Path source, final Path target, Logger log) throws IOException{
+
+		CamusJob.startTiming("copy-rename-commit");
+		
+		log.info("Using the Two Steps Process Copy to Temp and then rename to target.");
+		TaskAttemptContext context = (TaskAttemptContext) job;
+		long startTime = System.currentTimeMillis();
+		final FileSystem fs = FileSystem.get(job.getConfiguration());
+	    // now create a temp directory for this task file to copy..
+		Path parentpath = target.getParent();
+		// lets create a temp directory....
+		final TaskAttemptContext taskContext = (TaskAttemptContext) job;
+		final String tempLocation = parentpath.toString() + "/_temporary_"+taskContext.getTaskAttemptID().toString() +"/";
+		final Path tempPath = new Path(tempLocation);
+		// create retry logic for all file command 
+		RetryLogic<Boolean> retryWithTrueExpected = new RetryLogic<Boolean>(MAX_RETRY, WAIT_SECONDS, TimeUnit.SECONDS,Boolean.TRUE);
+		
+		boolean shouldCleanupTemp = false;
+		try{
+				log.info("Starting copy-rename-commit at " +  new Date());	
+				/**
+				 * Ideally, this should check if target file is there or not if it is there than we should move or not based on 
+				 * configuration otherwise we have major problem data overridden by this command.
+				 */
+				// check if file can be overridden if the destination path is there or not..
+				if(!EtlMultiOutputFormat.isFinalDestinationFileOverwriteOn(job)){
+					final FileExistsTask fileExists = new FileExistsTask(fs, target);
+					final RetryLogic<Boolean> retryWithFalse = new RetryLogic<Boolean>( MAX_RETRY, WAIT_SECONDS,TimeUnit.SECONDS, Boolean.FALSE);
+					try {							
+						boolean isFileFound  = retryWithFalse.getResultWithRetry(fileExists);
+						if(isFileFound){
+							throw new IOException("Target File="+target.toString() +" already exists and " + EtlMultiOutputFormat.ETL_FINAL_DESTINATION_FILE_OVERWRITE +" is OFF. Hence, the erorr message thrown to prevent data loss and overwrite file.");
+						}
+					} catch (RetryExhausted e) {
+						String msg = "Target File="+target.toString() +" exists check failed and " + EtlMultiOutputFormat.ETL_FINAL_DESTINATION_FILE_OVERWRITE +" is OFF. "
+									+ "Hence, the erorr message thrown to prevent data loss and overwrite.";
+						throw new IOException(msg,e);
+					}
+				}
+				
+				FileMakeDirTask makeTempDir = new FileMakeDirTask(fs,tempPath);
+					
+				boolean tempDirectoryCreated = false;
+				try {
+					tempDirectoryCreated = retryWithTrueExpected.getResultWithRetry(makeTempDir);
+				} catch (Exception e) {
+					log.error("Could not commit file due to error exit....",e);
+					// this will cause entire Map task to fail so we can start from last offset again  three for no data loss ???
+					throw new RuntimeException("Temp Folder Creation failed...",e);
+				}
+				
+				if(tempDirectoryCreated){
+					shouldCleanupTemp = tempDirectoryCreated;
+					//now try to move this file to temp folder...
+					
+					try {
+						final FileCopyToTempTask copyToTempDir = new FileCopyToTempTask(tempLocation, source, fs);
+						// now we have copied to respective volume so let try to rename it....this should not fail at all ....
+						final boolean copyToTempFolderFile = retryWithTrueExpected.getResultWithRetry(copyToTempDir);
+						if(copyToTempFolderFile && copyToTempDir.getTempPath() !=  null){					
+							FileRenameTask renameFromTempToFinalDestination =  new FileRenameTask(fs, copyToTempDir.getTempPath(), target);
+							boolean  finalResult = retryWithTrueExpected.getResultWithRetry(renameFromTempToFinalDestination);
+							if(finalResult){
+								// do not do retry here....
+								// it is ok if it does not get deleted since we have directory clean up will take care of it...
+								boolean delte = fs.delete(source,true);
+								if(!delte){
+									// last try to delete it with Hadoop M/R framework...
+									fs.deleteOnExit(source);
+								}
+							}else{
+								String message =  "File rename failed at this movement due to underlying FileSystem rename return false. Error is thrown so offset does not advance, hence no data loss.\n"+
+										  "source=" + source.toString() + " \n" +
+										  "final target= " + target.toString() + "\n";
+						
+								log.error(message);
+								throw new RuntimeException(message);
+							}
+						}
+					} catch (Exception e) {
+						if(e instanceof InterruptedException){
+							log.error("Giving up commit rename since this tread was inturupted: " + source.toString() +" and to=" + tempLocation,e);
+							Thread.currentThread().interrupt();
+						}else if(e instanceof RuntimeException){
+							log.error("Giving up commit rename since the copy failed: " + source.toString() +" and to=" + tempLocation,e);
+							throw (RuntimeException)e;
+						// any this expected result or IOException we must throw exception..
+						}else if (e instanceof RetryExhausted){
+							String message =  "File can not be commited at this movement so lets try next time due to underlying FileSystem erorr. Error is thrown so offset does not advance, hence no data loss.\n"+
+									  "source=" + source.toString() + " \n" +
+									  "final target= " + target.toString() + "\n";
+					
+							log.error(message);
+							throw new RuntimeException(message,e); 
+						}else{
+							log.error("Giving up commit rename since the copy failed: " + source.toString() +" and to=" + tempLocation,e);
+							throw new RuntimeException("Giving up commit since the copy failed" + source.toString() +" and to=" + tempLocation,e);
+						}
+					}
+				}
+		
+		}finally{
+			// finally delete the temp location....
+			 //partition_month_utc=2015-03/partition_day_utc=2015-03-11/partition_minute_bucket=2015-03-11-02-09/_temporary_attempt_201503102148_0007_m_000017_0
+			//if temp dir creation was successful then try to delete it..
+			if(shouldCleanupTemp){
+				try {
+					DirDeleteTask task = new DirDeleteTask(fs,tempPath);
+					boolean result = retryWithTrueExpected.getResultWithRetry(task);
+					if(!result){
+						boolean tempLocationDel =  fs.delete(tempPath, true);
+						if(!tempLocationDel){
+							// give second chance for the deleting the tempDir...by the hadoop framework if it failed......
+							log.error("Filed to clean up temp dir=" + tempPath.toString());
+							fs.deleteOnExit(tempPath);
+						}
+					}
+				} catch (RetryExhausted e) {
+					log.error("Filed to clean up temp directory in finally block tempdir=" + tempPath.toString());
+				}catch(Throwable th){
+					log.error("FATAL ERORR while delete finally block tempdir=" + tempPath.toString());
+				}
+			}
+			CamusJob.stopTiming("copy-rename-commit");
+			long duration = System.currentTimeMillis() - startTime;
+			log.info("Finish copy-rename-commit at " +  new Date() + " and duration (ms) is " + duration );	
+			updateCommitCounter(context,log,duration);
+		}		
+	}
+	
+	/**
+	 * Added Counter for this Copy-Task for Hadoop 1.0 and Hadoop 2.0 task.
+	 * @param context
+	 * @param log
+	 * @param value
+	 */
+	private static void updateCommitCounter(TaskAttemptContext context, Logger log, long value) {
+	    try {
+	      //In Hadoop 2, TaskAttemptContext.getCounter() is available
+	      Method getCounterMethod = context.getClass().getMethod("getCounter", String.class, String.class);
+	      Counter counter = ((Counter) getCounterMethod.invoke(context, "total", "copy-rename-commit"));
+	      counter.increment(value);
+	    } catch (NoSuchMethodException e) {
+	      //In Hadoop 1, TaskAttemptContext.getCounter() is not available
+	      //Have to cast context to TaskAttemptContext in the mapred package, then get a StatusReporter instance
+	      org.apache.hadoop.mapred.TaskAttemptContext mapredContext = (org.apache.hadoop.mapred.TaskAttemptContext) context;
+	      org.apache.hadoop.mapreduce.Counter counter = ((StatusReporter) mapredContext.getProgressible()).getCounter("total", "copy-rename-commit");
+	      counter.increment(value);
+	    } catch (IllegalArgumentException e) {
+	      log.error("IllegalArgumentException while obtaining counter 'total:copy-rename-commit': " + e.getMessage());
+	      throw new RuntimeException(e);
+	    } catch (IllegalAccessException e) {
+	      log.error("IllegalAccessException while obtaining counter 'total:copy-rename-commit': " + e.getMessage());
+	      throw new RuntimeException(e);
+	    } catch (InvocationTargetException e) {
+	      log.error("InvocationTargetException obtaining counter 'total:copy-rename-commit': " + e.getMessage());
+	      throw new RuntimeException(e);
+	    }
+	  }	
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileCopyToTempTask.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileCopyToTempTask.java
@@ -1,0 +1,70 @@
+package com.linkedin.camus.etl.kafka.utils.io;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+import com.linkedin.camus.etl.kafka.utils.RetryLogic;
+
+public final class FileCopyToTempTask implements RetryLogic.Delegate<Boolean> {
+	
+	private static final Logger log = Logger.getLogger(FileCopyToTempTask.class);
+	
+	private String tempLocation;
+	private Path source;
+	private FileSystem fs;
+	private Path tempFilePath;
+
+	FileCopyToTempTask(String tempLocation, Path source, FileSystem fs){
+		this.tempLocation = tempLocation;
+		this.source = source;
+		this.fs = fs;
+	}
+	
+	@Override
+	public Boolean call(){
+		Path destinationTemp = new Path(tempLocation + "/" + source.getName());
+		boolean result = false;
+		int retry = 3;
+		// for ANY fatal underlying FS error try 3 more times... 
+		// try to create a temp directory try 3 times if there is any failure then do not try...
+		while(retry > 0 && !result){
+			Path origDestinationTemp = new Path(destinationTemp.toString());
+			try{
+				result = FileUtil.copy(fs, source, fs,
+						destinationTemp, false, fs.getConf());
+				tempFilePath = destinationTemp;
+				
+				if(!result){
+					log.error("Failed rename to temp destination Path so delete it : " + destinationTemp.toString());
+					// if result is failure then lets delete it now...
+					boolean deleted = fs.delete(destinationTemp,true);
+					if(!deleted){
+						// let see if hadoop framework can delete this..otherwise this will be garbage sitting here for ever and ever...TODO ????
+						fs.deleteOnExit(destinationTemp);
+						// try new path...
+						destinationTemp = new Path(destinationTemp.toString() + "-"+retry);
+					}
+				}
+			}catch(IOException e){
+				log.error("Error while copy to temp location from=" + source.toString() +" and to=" + origDestinationTemp.toString(),e);
+				try{
+					// try to close file and delete it... TODO Review this....
+					fs.create(origDestinationTemp,true).close();
+					fs.delete(origDestinationTemp, true);
+				}catch(Throwable th){
+					log.error("Error delete while copy to temp location from=" + source.toString() +" and to=" + origDestinationTemp.toString(),e);								}
+				
+			}
+		}
+		return result;
+	}
+	
+	public Path getTempPath(){
+		return tempFilePath;
+	}
+
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileExistsTask.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileExistsTask.java
@@ -1,0 +1,32 @@
+package com.linkedin.camus.etl.kafka.utils.io;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+import com.linkedin.camus.etl.kafka.utils.RetryLogic;
+
+public final class FileExistsTask implements RetryLogic.Delegate<Boolean> {
+	
+	private static final Logger log = Logger.getLogger(FileExistsTask.class);
+
+	
+	private FileSystem fs;
+	private Path path;
+	
+	public FileExistsTask(FileSystem fs,Path path ){
+		if(fs == null || path == null){
+			throw new NullPointerException("FileSystem object fs or Path path cannot be null!");
+		} 
+		this.fs = fs ;
+		this.path = path;
+	}
+
+	@Override
+	public Boolean call() throws Exception {
+		boolean result = fs.exists(path);
+		log.info("Checking file if file Path exists["+result+"]:" + path.toString());
+		return result;
+	}
+
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileMakeDirTask.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileMakeDirTask.java
@@ -1,0 +1,40 @@
+package com.linkedin.camus.etl.kafka.utils.io;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+import com.linkedin.camus.etl.kafka.utils.RetryLogic;
+
+public class FileMakeDirTask implements RetryLogic.Delegate<Boolean> {
+
+	private static final Logger log = Logger.getLogger(FileMakeDirTask.class);
+
+	
+	private FileSystem fs;
+	private Path path;
+	
+	public FileMakeDirTask(FileSystem fs,Path path ){
+		if(fs == null || path == null){
+			throw new NullPointerException("FileSystem object fs or Path path cannot be null!");
+		} 
+		this.fs = fs ;
+		this.path = path;
+	}
+	
+	@Override
+	public Boolean call() throws Exception {		
+		boolean result = false;
+		boolean dirExists = fs.exists(path);
+		if(dirExists){
+			log.info("Path :" + path.toString() + "exits already");
+			result = dirExists;
+		}else {
+			result = fs.mkdirs(path);
+			// double check if file is created or not..
+			result = fs.exists(path);
+		}
+		return result;
+	}
+
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileRenameTask.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/utils/io/FileRenameTask.java
@@ -1,0 +1,73 @@
+package com.linkedin.camus.etl.kafka.utils.io;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+import com.linkedin.camus.etl.kafka.utils.RetryLogic;
+
+public class FileRenameTask implements RetryLogic.Delegate<Boolean>{
+	
+	
+	private Logger log = Logger.getLogger(FileRenameTask.class);
+	
+	private FileSystem fs;
+	private Path soruce;
+	private Path target;
+	
+	
+	
+	private boolean isFirstCall = true;
+	private boolean fileAlreadyExits = false;
+
+	public FileRenameTask(FileSystem fs,Path source, Path target ){
+		if(fs == null){
+			throw new NullPointerException("FileSystem  fs cannot be null");
+		} 
+		if(source == null){
+			throw new NullPointerException("source cannot be null");
+		}
+		if(target == null){
+			throw new NullPointerException("target cannot be null");
+		}		
+		this.fs = fs ;
+		this.soruce = source;
+		this.target = target;
+	}
+	
+	
+	/**
+	 * Any IO Exception retry will happen...
+	 */
+	@Override
+	public Boolean call() throws Exception {
+		boolean result = false;
+        // check if file exits...
+		if(fs.exists(soruce)){
+			boolean fileExists = fs.exists(target);
+			if( fileExists && isFirstCall){
+				isFirstCall = false;
+				String message = "Cannot rename File target File["+target.toString()+"] already exits final destination path."; 
+				fileAlreadyExits = true;
+				throw new IOException(message);
+			}
+			// not first call any more...
+			isFirstCall = false;
+			// first time file does not exist but may be it does exist after FS failure while renaming...
+			if(!fileAlreadyExits){
+				//try to rename it ...
+				result = fs.rename(soruce,target);
+				if(!result){
+					String msg = "Failed to commit the file to final destination ="+target.toString() + " and temp path="+soruce.toString();
+					log.error(msg);
+					result =false;
+					throw new IOException(msg);
+				}
+			}			
+		}
+		return result;
+	}
+
+}

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/utils/RetryLogicTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/utils/RetryLogicTest.java
@@ -1,0 +1,154 @@
+package com.linkedin.camus.etl.kafka.utils;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RetryLogicTest {
+	
+
+	@Test
+	public void testGetResultWithRetryFailureRetryExhausted() {
+		
+		RetryLogic<Boolean> retryLogic = new 
+				RetryLogic<Boolean>(3, 1, TimeUnit.SECONDS, Boolean.TRUE);
+		boolean gotRetryExhausted = false;
+		long start = System.currentTimeMillis();
+		long end = 0;
+		TestFailureDueToException test  = new TestFailureDueToException();
+		CounterWrapper<Boolean> counter = new CounterWrapper<Boolean>(test);
+		try {
+			retryLogic.getResultWithRetry(counter);
+		} catch (RetryExhausted e) {
+			end = System.currentTimeMillis();
+			gotRetryExhausted = true;
+		}
+		Assert.assertTrue(gotRetryExhausted);	
+		Assert.assertTrue(end > 0);	
+		//must wait for 2 sec total  between 3 retry ....
+		Assert.assertTrue(TimeUnit.MILLISECONDS.toSeconds(end-start) >= 2 );
+		Assert.assertTrue(counter.getCount() == 3);
+	}
+
+	@Test
+	public void testGetResultWithRetryFailureRetryExhaustedDueToUnexpectedResult() {
+		
+		RetryLogic<Boolean> retryLogic = new 
+				RetryLogic<Boolean>(3, 1, TimeUnit.SECONDS, Boolean.TRUE);
+		boolean gotRetryExhausted = false;
+		long start = System.currentTimeMillis();
+		long end = 0;
+		TestFailureDueToExceptionUnExpectedResult test  = new TestFailureDueToExceptionUnExpectedResult();
+
+		CounterWrapper<Boolean> counter = new CounterWrapper<Boolean>(test);
+		Boolean result = null;
+		try {
+			result = retryLogic.getResultWithRetry(counter);
+			end = System.currentTimeMillis();
+		} catch (RetryExhausted e) {
+			gotRetryExhausted = true;
+			Assert.assertTrue(!e.hasException());
+		}
+		Assert.assertTrue(!gotRetryExhausted);	
+		Assert.assertFalse(result);	
+		Assert.assertTrue(end > 0);	
+		//must wait for 2 sec total  between 3 retry ....
+		Assert.assertTrue(TimeUnit.MILLISECONDS.toSeconds(end-start) >= 2 );
+	}
+	
+
+	@Test
+	public void testGetResultWithRetryHappyCases() {
+		
+		RetryLogic<Boolean> retryLogic = new 
+				RetryLogic<Boolean>(3, 1, TimeUnit.SECONDS, Boolean.TRUE);
+		boolean gotRetryExhausted = false;
+		long start = System.currentTimeMillis();
+		long end = 0;
+		TestHappyResult test  = new TestHappyResult();
+
+		CounterWrapper<Boolean> counter = new CounterWrapper<Boolean>(test);
+		try {
+			retryLogic.getResultWithRetry(counter);
+			end = System.currentTimeMillis();
+		} catch (RetryExhausted e) {
+			gotRetryExhausted = true;
+		}
+		Assert.assertFalse(gotRetryExhausted);	
+		Assert.assertTrue(end > 0);	
+		//must wait for 2 sec total  between 3 retry ....
+		Assert.assertTrue(TimeUnit.MILLISECONDS.toSeconds(end-start) < 2 );
+		Assert.assertTrue(counter.getCount() == 1);
+		
+		TestHappyResultAfterFailure test2  = new TestHappyResultAfterFailure();
+		CounterWrapper<Boolean> counter2 = new CounterWrapper<Boolean>(test2);
+		try {
+			start = System.currentTimeMillis();
+			retryLogic.getResultWithRetry(counter2);
+			end = System.currentTimeMillis();
+		} catch (RetryExhausted e) {
+			gotRetryExhausted = true;
+		}
+		Assert.assertFalse(gotRetryExhausted);	
+		Assert.assertTrue(end > 0);	
+		//must wait for 2 sec total  between 3 retry ....
+		Assert.assertTrue(TimeUnit.MILLISECONDS.toSeconds(end-start) <= 2 );
+		Assert.assertTrue(counter2.getCount() == 2);		
+	}
+	
+	
+	
+	static class CounterWrapper<T> implements RetryLogic.Delegate<T> {
+		int count = 0;
+		RetryLogic.Delegate<T> test;
+		CounterWrapper(RetryLogic.Delegate<T> test){
+			this.test = test;
+		}
+		
+		@Override
+		public T call() throws Exception {
+			count++;
+			return test.call();
+		}
+		
+		public int getCount(){
+			return count;
+		}
+	}	
+	
+	
+	
+	static class TestFailureDueToException implements RetryLogic.Delegate<Boolean> {
+		@Override
+		public Boolean call() {
+			throw new RuntimeException("Failed Operation..all time");
+		}
+		
+	}
+	static class TestFailureDueToExceptionUnExpectedResult implements RetryLogic.Delegate<Boolean> {
+		@Override
+		public Boolean call() {
+			return Boolean.FALSE;
+		}
+	}
+	
+	static class TestHappyResult implements RetryLogic.Delegate<Boolean> {
+		@Override
+		public Boolean call() {
+			return Boolean.TRUE;
+		}
+	}
+	static class TestHappyResultAfterFailure implements RetryLogic.Delegate<Boolean> {
+		private boolean isFirstOne = true;
+		@Override
+		public Boolean call() {
+			
+			if(isFirstOne){
+				isFirstOne = false;
+				throw new RuntimeException("First TIme Failure..");
+			}
+			return Boolean.TRUE;
+		}
+	}
+}

--- a/camus-example/pom.xml
+++ b/camus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-example</artifactId>

--- a/camus-kafka-coders/pom.xml
+++ b/camus-kafka-coders/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.linkedin.camus</groupId>
 		<artifactId>camus-parent</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>0.1.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camus-kafka-coders</artifactId>

--- a/camus-schema-registry-avro/pom.xml
+++ b/camus-schema-registry-avro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-schema-registry-avro</artifactId>

--- a/camus-schema-registry/pom.xml
+++ b/camus-schema-registry/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-schema-registry</artifactId>

--- a/camus-sweeper/pom.xml
+++ b/camus-sweeper/pom.xml
@@ -57,7 +57,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>1.7.1</version>
+				<version>2.3</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/camus-sweeper/pom.xml
+++ b/camus-sweeper/pom.xml
@@ -4,12 +4,12 @@
 	<groupId>com.linkedin.camus</groupId>
 	<artifactId>camus-sweeper</artifactId>
 	<name>Camus compaction code small files produced Camus</name>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.1.1-SNAPSHOT</version>
 	
 	<parent>
 		<groupId>com.linkedin.camus</groupId>
 		<artifactId>camus-parent</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>0.1.1-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.linkedin.camus</groupId>
   <artifactId>camus-parent</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Camus Parent</name>
   <description>
@@ -26,27 +26,27 @@
       <dependency>
         <groupId>com.linkedin.camus</groupId>
 	<artifactId>camus-api</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.1.1-SNAPSHOT</version>
       </dependency>
       <dependency>
 	<groupId>com.linkedin.camus</groupId>
 	<artifactId>camus-etl-kafka</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.1.1-SNAPSHOT</version>
       </dependency>
       <dependency>
 	<groupId>com.linkedin.camus</groupId>
 	<artifactId>camus-kafka-coders</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.1.1-SNAPSHOT</version>
       </dependency>
       <dependency>
 	<groupId>com.linkedin.camus</groupId>
 	<artifactId>camus-schema-registry</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.1.1-SNAPSHOT</version>
       </dependency>		
       <dependency>
 	<groupId>com.linkedin.camus</groupId>
 	<artifactId>camus-schema-registry</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.1.1-SNAPSHOT</version>
 	<type>test-jar</type>
 	<scope>test</scope>
       </dependency>


### PR DESCRIPTION

| **Property Name**                                     | **Default Value** | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|---------------------------------------------------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| etl.final.file.overwrite                          | false         | This is safely option allow no data loss and rename does not overwrite file (e.g when hadoop job partially commits file or admin issue 'hadoop job -kill job_id' etc and file name get overwritten (This will allow to detect file duplication etc).  **FALSE:** This option will allow Final Destination file cannot be overwritten.,If final Destination Path exists that was generated by Partitioner Interface Class then it is fail the Camus Job.   **TRUE:** This option will allow Final Destination File can be overwritten.                                                                              |
| etl.output.two.steps.commit.copyToTemp.and.rename | false         | For Hadoop system when you have volume based directory(MapR) then you need this option and also avoid File getting access while it is getting written (using temp folder).  There is cost to this and "Total copy-rename-commit time(s): 10" under Timing Report.  **FALSE:**  When camus job goes out of range, it will not be move offset and camus job will continue to skip that partition and fail the job.  **TRUE:** When camus job goes out of range, it will automatically move to latest offset and job will not fail and data will be pulled from this partition.(True should be default in my opinion). |

**How to find the cost of "copy-temp-rename" strategy or having this "etl.output.two.steps.commit.copyToTemp.and.rename=true" ?**

Here is sample camus time report with cost in second "Total copy-rename-commit time(s): 10".  The cost is calculated as hadoop counter and should work with Hadoop 1.x or 2.x API.

FYI:  http://stackoverflow.com/questions/21868430/locking-a-directory-in-hdfs

