### PR TITLE
Add support to store not only payload

### DIFF
--- a/camus-api/src/main/java/com/linkedin/camus/coders/Message.java
+++ b/camus-api/src/main/java/com/linkedin/camus/coders/Message.java
@@ -1,0 +1,22 @@
+package com.linkedin.camus.coders;
+
+import java.io.IOException;
+
+/**
+ * Created by michaelandrepearce on 05/04/15.
+ */
+public interface Message {
+    byte[] getPayload();
+
+    byte[] getKey();
+
+    String getTopic();
+
+    long getOffset();
+
+    int getPartition();
+
+    long getChecksum();
+
+    void validate() throws IOException;
+}

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaMessage.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaMessage.java
@@ -1,0 +1,76 @@
+package com.linkedin.camus.etl.kafka.common;
+
+import kafka.message.Message;
+import org.apache.hadoop.fs.ChecksumException;
+
+import java.io.IOException;
+
+/**
+ * Created by michaelandrepearce on 05/04/15.
+ */
+public class KafkaMessage implements com.linkedin.camus.coders.Message {
+
+    byte[] payload;
+    byte[] key;
+
+    private String topic = "";
+    private long offset = 0;
+    private int partition = 0;
+    private long checksum = 0;
+
+
+    public KafkaMessage(byte[] payload, byte[] key, String topic, int partition, long offset, long checksum){
+        this.payload = payload;
+        this.key = key;
+        this.topic = topic;
+        this.partition = partition;
+        this.offset = offset;
+        this.checksum = checksum;
+    }
+
+    @Override
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    @Override
+    public byte[] getKey() {
+        return key;
+    }
+
+    @Override
+    public String getTopic() {
+        return topic;
+    }
+
+    @Override
+    public long getOffset() {
+        return offset;
+    }
+
+    @Override
+    public int getPartition() {
+        return partition;
+    }
+
+    @Override
+    public long getChecksum() {
+        return checksum;
+    }
+
+    public void validate() throws IOException {
+        // check the checksum of message.
+        Message readMessage;
+        if (key == null){
+            readMessage = new Message(payload);
+        } else {
+            readMessage = new Message(payload, key);
+        }
+
+        if (checksum != readMessage.checksum()) {
+            throw new ChecksumException("Invalid message checksum : " + readMessage.checksum() + ". Expected " + checksum,
+                    offset);
+        }
+    }
+
+}

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
@@ -3,6 +3,7 @@ package com.linkedin.camus.etl.kafka.coders;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.coders.Message;
 import com.linkedin.camus.coders.MessageDecoder;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
@@ -32,7 +33,7 @@ import java.util.Properties;
  * This MessageDecoder returns a CamusWrapper that works with Strings payloads,
  * since JSON data is always a String.
  */
-public class JsonStringMessageDecoder extends MessageDecoder<byte[], String> {
+public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
   private static final org.apache.log4j.Logger log = Logger.getLogger(JsonStringMessageDecoder.class);
 
   // Property for format of timestamp in JSON timestamp field.
@@ -59,16 +60,16 @@ public class JsonStringMessageDecoder extends MessageDecoder<byte[], String> {
   }
 
   @Override
-  public CamusWrapper<String> decode(byte[] payload) {
+  public CamusWrapper<String> decode(Message message) {
     long timestamp = 0;
     String payloadString;
     JsonObject jsonObject;
 
     try {
-      payloadString = new String(payload, "UTF-8");
+      payloadString = new String(message.getPayload(), "UTF-8");
     } catch (UnsupportedEncodingException e) {
       log.error("Unable to load UTF-8 encoding, falling back to system default", e);
-      payloadString = new String(payload);
+      payloadString = new String(message.getPayload());
     }
 
     // Parse the payload into a JsonObject.

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonWrappedStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonWrappedStringMessageDecoder.java
@@ -1,0 +1,169 @@
+package com.linkedin.camus.etl.kafka.coders;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.coders.Message;
+import com.linkedin.camus.coders.MessageDecoder;
+import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+import java.io.UnsupportedEncodingException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Properties;
+
+
+/**
+ * MessageDecoder class that will convert the payload, and key into a JSON object,
+ * wrap the key and payload into a wrapped JSON object, with addtional message details.
+ * look for a the camus.message.timestamp.field, convert that timestamp to
+ * a unix epoch long using camus.message.timestamp.format, and then set the CamusWrapper's
+ * timestamp property to the record's timestamp.  If the JSON does not have
+ * a timestamp or if the timestamp could not be parsed properly, then
+ * System.currentTimeMillis() will be used.
+ * <p/>
+ * camus.message.timestamp.format will be used with SimpleDateFormat.  If your
+ * camus.message.timestamp.field is stored in JSON as a unix epoch timestamp,
+ * you should set camus.message.timestamp.format to 'unix_seconds' (if your
+ * timestamp units are seconds) or 'unix_milliseconds' (if your timestamp units
+ * are milliseconds).
+ * <p/>
+ * This MessageDecoder returns a CamusWrapper that works with Strings payloads,
+ * since JSON data is always a String.
+ */
+public class JsonWrappedStringMessageDecoder extends MessageDecoder<Message, String> {
+  private static final Logger log = Logger.getLogger(JsonWrappedStringMessageDecoder.class);
+
+  // Property for format of timestamp in JSON timestamp field.
+  public static final String CAMUS_MESSAGE_TIMESTAMP_FORMAT = "camus.message.timestamp.format";
+  public static final String DEFAULT_TIMESTAMP_FORMAT = "[dd/MMM/yyyy:HH:mm:ss Z]";
+
+  // Property for the JSON field name of the timestamp.
+  public static final String CAMUS_MESSAGE_TIMESTAMP_FIELD = "camus.message.timestamp.field";
+  public static final String DEFAULT_TIMESTAMP_FIELD = "timestamp";
+
+  JsonParser jsonParser = new JsonParser();
+  DateTimeFormatter dateTimeParser = ISODateTimeFormat.dateTimeParser();
+
+  private String timestampFormat;
+  private String timestampField;
+
+
+  @Override
+  public void init(Properties props, String topicName) {
+    this.props = props;
+    this.topicName = topicName;
+
+    timestampFormat = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FORMAT, DEFAULT_TIMESTAMP_FORMAT);
+    timestampField = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FIELD, DEFAULT_TIMESTAMP_FIELD);
+  }
+
+  @Override
+  public CamusWrapper<String> decode(Message message) {
+
+    JsonObject messageJsonObject = new JsonObject();
+    messageJsonObject.addProperty("topic", message.getTopic());
+    messageJsonObject.addProperty("partition", message.getPartition());
+    messageJsonObject.addProperty("offset", message.getOffset());
+    messageJsonObject.addProperty("checksum", message.getChecksum());
+
+    JsonObject payloadJsonObject = toJson(message.getPayload());
+    messageJsonObject.add("payload", payloadJsonObject);
+
+    JsonObject keyJsonObject = toJson(message.getKey());
+    messageJsonObject.add("key", keyJsonObject);
+
+    long timestamp = getTimestamp(payloadJsonObject);
+
+    messageJsonObject.addProperty("timestamp", timestamp);
+
+    return new CamusWrapper<String>(messageJsonObject.toString(), timestamp);
+  }
+
+  private JsonObject toJson(byte[] bytes) {
+    if (bytes == null) return null;
+    return toJson(toString(bytes));
+  }
+
+  private JsonObject toJson(String string) {
+    if (string == null) return null;
+    JsonObject jsonObject;// Parse the payload into a JsonObject.
+    try {
+      jsonObject = jsonParser.parse(string.trim()).getAsJsonObject();
+    } catch (RuntimeException e) {
+      log.error("Caught exception while parsing JSON string '" + string + "'.");
+      throw new RuntimeException(e);
+    }
+    return jsonObject;
+  }
+
+  private String toString(byte[] bytes) {
+    if (bytes == null) return null;
+    String string;
+
+    try {
+      string = new String(bytes, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      log.error("Unable to load UTF-8 encoding, falling back to system default", e);
+      string = new String(bytes);
+    }
+    return string;
+  }
+
+  private long getTimestamp(JsonObject jsonObject) {
+    long timestamp = 0;
+
+    // Attempt to read and parse the timestamp element into a long.
+    if (jsonObject != null && jsonObject.has(timestampField)) {
+      // If timestampFormat is 'unix_seconds',
+      // then the timestamp only needs converted to milliseconds.
+      // Also support 'unix' for backwards compatibility.
+      if (timestampFormat.equals("unix_seconds") || timestampFormat.equals("unix")) {
+        timestamp = jsonObject.get(timestampField).getAsLong();
+        // This timestamp is in seconds, convert it to milliseconds.
+        timestamp = timestamp * 1000L;
+      }
+      // Else if this timestamp is already in milliseconds,
+      // just save it as is.
+      else if (timestampFormat.equals("unix_milliseconds")) {
+        timestamp = jsonObject.get(timestampField).getAsLong();
+      }
+      // Else if timestampFormat is 'ISO-8601', parse that
+      else if (timestampFormat.equals("ISO-8601")) {
+        String timestampString = jsonObject.get(timestampField).getAsString();
+        try {
+          timestamp = new DateTime(timestampString).getMillis();
+        } catch (IllegalArgumentException e) {
+          log.error("Could not parse timestamp '" + timestampString + "' as ISO-8601 while decoding JSON message.");
+        }
+      }
+      // Otherwise parse the timestamp as a string in timestampFormat.
+      else {
+        String timestampString = jsonObject.get(timestampField).getAsString();
+        try {
+          timestamp = dateTimeParser.parseDateTime(timestampString).getMillis();
+        } catch (IllegalArgumentException e) {
+          try {
+            timestamp = new SimpleDateFormat(timestampFormat).parse(timestampString).getTime();
+          } catch (ParseException pe) {
+            log.error("Could not parse timestamp '" + timestampString + "' while decoding JSON message.");
+          }
+        } catch (Exception ee) {
+          log.error("Could not parse timestamp '" + timestampString + "' while decoding JSON message.");
+        }
+      }
+    }
+
+    // If timestamp wasn't set in the above block,
+    // then set it to current time.
+    if (timestamp == 0) {
+      log.warn("Couldn't find or parse timestamp field '" + timestampField
+          + "' in JSON message, defaulting to current time.");
+      timestamp = System.currentTimeMillis();
+    }
+    return timestamp;
+  }
+}

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/KafkaAvroMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/KafkaAvroMessageDecoder.java
@@ -4,8 +4,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Properties;
 
-import kafka.message.Message;
-
+import com.linkedin.camus.coders.Message;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericDatumReader;
@@ -20,7 +19,7 @@ import com.linkedin.camus.schemaregistry.SchemaRegistry;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
-public class KafkaAvroMessageDecoder extends MessageDecoder<byte[], Record> {
+public class KafkaAvroMessageDecoder extends MessageDecoder<Message, Record> {
   private static final Logger log = Logger.getLogger(KafkaAvroMessageDecoder.class);
       
   protected DecoderFactory decoderFactory;
@@ -110,9 +109,9 @@ public class KafkaAvroMessageDecoder extends MessageDecoder<byte[], Record> {
     }
   }
 
-  public CamusWrapper<Record> decode(byte[] payload) {
+  public CamusWrapper<Record> decode(Message message) {
     try {
-      MessageDecoderHelper helper = new MessageDecoderHelper(registry, topicName, payload).invoke();
+      MessageDecoderHelper helper = new MessageDecoderHelper(registry, topicName, message.getPayload()).invoke();
       DatumReader<Record> reader =
           (helper.getTargetSchema() == null) ? new GenericDatumReader<Record>(helper.getSchema())
               : new GenericDatumReader<Record>(helper.getSchema(), helper.getTargetSchema());

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/LatestSchemaKafkaAvroMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/LatestSchemaKafkaAvroMessageDecoder.java
@@ -1,7 +1,7 @@
 package com.linkedin.camus.etl.kafka.coders;
 
-import kafka.message.Message;
 
+import com.linkedin.camus.coders.Message;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericDatumReader;
@@ -13,7 +13,7 @@ import com.linkedin.camus.coders.CamusWrapper;
 public class LatestSchemaKafkaAvroMessageDecoder extends KafkaAvroMessageDecoder {
 
   @Override
-  public CamusWrapper<Record> decode(byte[] payload) {
+  public CamusWrapper<Record> decode(Message message) {
     try {
       GenericDatumReader<Record> reader = new GenericDatumReader<Record>();
 
@@ -21,9 +21,9 @@ public class LatestSchemaKafkaAvroMessageDecoder extends KafkaAvroMessageDecoder
 
       reader.setSchema(schema);
 
-      return new CamusWrapper<Record>(reader.read(null, decoderFactory.jsonDecoder(schema, new String(payload,
+      return new CamusWrapper<Record>(reader.read(null, decoderFactory.jsonDecoder(schema, new String(message.getPayload(),
       //Message.payloadOffset(message.magic()),
-          Message.MagicOffset(), payload.length - Message.MagicOffset()))));
+          kafka.message.Message.MagicOffset(), message.getPayload().length - kafka.message.Message.MagicOffset()))));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/camus-kafka-coders/src/test/java/com/linkedin/camus/etl/kafka/coders/TestJsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/test/java/com/linkedin/camus/etl/kafka/coders/TestJsonStringMessageDecoder.java
@@ -26,7 +26,7 @@ public class TestJsonStringMessageDecoder {
     String payload = "{\"timestamp\":  " + expectedTimestamp + ", \"myData\": \"myValue\"}";
     byte[] bytePayload = payload.getBytes();
 
-    CamusWrapper actualResult = testDecoder.decode(bytePayload);
+    CamusWrapper actualResult = testDecoder.decode(new TestMessage().setPayload(bytePayload));
     long actualTimestamp = actualResult.getTimestamp();
     assertEquals(expectedTimestamp, actualTimestamp);
   }
@@ -47,7 +47,7 @@ public class TestJsonStringMessageDecoder {
     testDecoder.init(testProperties, "testTopic");
     String payload = "{\"timestamp\":  " + testTimestamp + ", \"myData\": \"myValue\"}";
     byte[] bytePayload = payload.getBytes();
-    CamusWrapper actualResult = testDecoder.decode(bytePayload);
+    CamusWrapper actualResult = testDecoder.decode(new TestMessage().setPayload(bytePayload));
     long actualTimestamp = actualResult.getTimestamp();
 
     assertEquals(expectedTimestamp, actualTimestamp);
@@ -70,7 +70,7 @@ public class TestJsonStringMessageDecoder {
     testDecoder.init(testProperties, "testTopic");
     String payload = "{\"timestamp\":  \"" + testTimestamp + "\", \"myData\": \"myValue\"}";
     byte[] bytePayload = payload.getBytes();
-    CamusWrapper actualResult = testDecoder.decode(bytePayload);
+    CamusWrapper actualResult = testDecoder.decode(new TestMessage().setPayload(bytePayload));
     long actualTimestamp = actualResult.getTimestamp();
 
     assertEquals(expectedTimestamp, actualTimestamp);
@@ -94,14 +94,14 @@ public class TestJsonStringMessageDecoder {
     testDecoder.init(testProperties, "testTopic");
     String payload = "{\"timestamp\":  \"" + testTimestamp1 + "\", \"myData\": \"myValue\"}";
     byte[] bytePayload = payload.getBytes();
-    CamusWrapper actualResult = testDecoder.decode(bytePayload);
+    CamusWrapper actualResult = testDecoder.decode(new TestMessage().setPayload(bytePayload));
     long actualTimestamp = actualResult.getTimestamp();
 
     assertEquals(expectedTimestamp, actualTimestamp);
 
     payload = "{\"timestamp\":  \"" + testTimestamp2 + "\", \"myData\": \"myValue\"}";
     bytePayload = payload.getBytes();
-    actualResult = testDecoder.decode(bytePayload);
+    actualResult = testDecoder.decode(new TestMessage().setPayload(bytePayload));
     actualTimestamp = actualResult.getTimestamp();
 
     assertEquals(expectedTimestamp, actualTimestamp);
@@ -112,7 +112,7 @@ public class TestJsonStringMessageDecoder {
     byte[] bytePayload = "{\"key: value}".getBytes();
 
     JsonStringMessageDecoder testDecoder = new JsonStringMessageDecoder();
-    testDecoder.decode(bytePayload);
+    testDecoder.decode(new TestMessage().setPayload(bytePayload));
   }
 
 }

--- a/camus-kafka-coders/src/test/java/com/linkedin/camus/etl/kafka/coders/TestMessage.java
+++ b/camus-kafka-coders/src/test/java/com/linkedin/camus/etl/kafka/coders/TestMessage.java
@@ -1,0 +1,79 @@
+package com.linkedin.camus.etl.kafka.coders;
+
+import com.linkedin.camus.coders.Message;
+
+import java.io.IOException;
+
+/**
+ * Created by michaelandrepearce on 05/04/15.
+ */
+public class TestMessage implements Message {
+
+    byte[] payload;
+    byte[] key;
+
+    private String topic = "";
+    private long offset = 0;
+    private int partition = 0;
+    private long checksum = 0;
+
+
+    public byte[] getPayload() {
+        return this.payload;
+    }
+
+    public TestMessage setPayload(byte[] payload) {
+        this.payload = payload;
+        return this;
+    }
+
+    public byte[] getKey() {
+        return this.key;
+    }
+
+    public TestMessage setKey(byte[] key) {
+        this.key = key;
+        return this;
+    }
+
+    public String getTopic() {
+        return this.topic;
+    }
+
+    public TestMessage setTopic(String topic) {
+        this.topic = topic;
+        return this;
+    }
+
+    public long getOffset() {
+        return this.offset;
+    }
+
+    public TestMessage setOffset(long offset) {
+        this.offset = offset;
+        return this;
+    }
+
+    public int getPartition() {
+        return this.partition;
+    }
+
+    public TestMessage setPartition(int partition) {
+        this.partition = partition;
+        return this;
+    }
+
+    public long getChecksum() {
+        return this.checksum;
+    }
+
+    @Override
+    public void validate() throws IOException {
+
+    }
+
+    public TestMessage setChecksum(long checksum) {
+        this.checksum = checksum;
+        return this;
+    }
+}


### PR DESCRIPTION
We have the requirement within our company to store not only the payload, but also the key, offset, partition, and checksums. So that we can replay the messages exactly as they were read from kafka.

Supplied additional decoder to store the additional data, where payload and key byte data is both json, and wraps this information in a json wrapper returned into the CamusWrapper as String.

Updated other coders, so behaviour for existing remains unchanged.

This is a merge from our internal clone of Camus.
