### PR TITLE
write mapper start timestamp to destination folder

### DIFF
--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
@@ -258,7 +258,7 @@ public class CamusHourlySweeper extends CamusSweeper {
     public Void call() throws IOException {
       String inputPaths = this.props.getProperty(CamusHourlySweeper.INPUT_PATHS);
       String outputPathStr = this.props.getProperty(CamusHourlySweeper.DEST_PATH);
-      long destinationModTime = getDestinationModTime(this.fs, outputPathStr, true);
+      long destinationModTime = getDestinationModTime(this.fs, outputPathStr);
       Path outputPath = new Path(outputPathStr, "outlier");
       fs.mkdirs(outputPath);
 
@@ -294,7 +294,7 @@ public class CamusHourlySweeper extends CamusSweeper {
    * If such a file doesn't exist, return the timestamp of the folder.
    * @throws IOException 
    */
-  public static long getDestinationModTime(FileSystem fs, String outputPathStr, boolean deleteTimestamp)
+  public static long getDestinationModTime(FileSystem fs, String outputPathStr)
       throws IOException {
     for (FileStatus status : fs.listStatus(new Path(outputPathStr))) {
       if (!status.isDir() && status.getPath().getName().equals(STATE_FILE_NAME)) {
@@ -306,10 +306,6 @@ public class CamusHourlySweeper extends CamusSweeper {
           properties.load(fin);
 
           long timeStamp = Long.valueOf(properties.getProperty(MAPREDUCE_SUBMIT_TIME));
-
-          if (deleteTimestamp) {
-            fs.delete(status.getPath(), false);
-          }
 
           return timeStamp;
         } finally {

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
@@ -147,7 +147,7 @@ public class CamusHourlySweeper extends CamusSweeper {
     return executorService.submit(new KafkaCollectorRunner(jobName, props, errorMessages, topic));
   }
 
-  private static void createTimeStampFileInFolder(FileSystem fs, Path folder, long timeStamp) throws IOException {
+  private static void createStateFileInFolder(FileSystem fs, Path folder, long timeStamp) throws IOException {
     // delete existing state file
     for (FileStatus status : fs.listStatus(folder)) {
       if (!status.isDir() && status.getPath().getName().equals(STATE_FILE_NAME)) {
@@ -219,7 +219,7 @@ public class CamusHourlySweeper extends CamusSweeper {
       CamusHourlySweeper.this.metrics.recordMrSubmitTimeByTopic(this.topicAndHour, jobSubmitTime);
       submitMrJob();
       moveTmpPathToOutputPath();
-      CamusHourlySweeper.createTimeStampFileInFolder(fs, this.outputPath, jobSubmitTime);
+      CamusHourlySweeper.createStateFileInFolder(fs, this.outputPath, jobSubmitTime);
     }
 
     @Override
@@ -276,7 +276,7 @@ public class CamusHourlySweeper extends CamusSweeper {
 
         // Create new timestamp file
         if (outlierMaxTimestamp != Long.MIN_VALUE) {
-          CamusHourlySweeper.createTimeStampFileInFolder(fs, new Path(outputPathStr), outlierMaxTimestamp);
+          CamusHourlySweeper.createStateFileInFolder(fs, new Path(outputPathStr), outlierMaxTimestamp);
         }
       }
 

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
@@ -253,7 +253,7 @@ public class CamusHourlySweeper extends CamusSweeper {
 
         // Create new timestamp file
         if (outlierMaxTimestamp != Long.MIN_VALUE) {
-          CamusHourlySweeper.createTimeStampFileInFolder(fs, inputPath, outlierMaxTimestamp);
+          CamusHourlySweeper.createTimeStampFileInFolder(fs, new Path(outputPathStr), outlierMaxTimestamp);
         }
       }
 

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
@@ -294,8 +294,7 @@ public class CamusHourlySweeper extends CamusSweeper {
    * If such a file doesn't exist, return the timestamp of the folder.
    * @throws IOException 
    */
-  public static long getDestinationModTime(FileSystem fs, String outputPathStr)
-      throws IOException {
+  public static long getDestinationModTime(FileSystem fs, String outputPathStr) throws IOException {
     for (FileStatus status : fs.listStatus(new Path(outputPathStr))) {
       if (!status.isDir() && status.getPath().getName().equals(STATE_FILE_NAME)) {
         LOG.info("Found state file: " + status.getPath());
@@ -304,10 +303,9 @@ public class CamusHourlySweeper extends CamusSweeper {
           fin = fs.open(status.getPath());
           Properties properties = new Properties();
           properties.load(fin);
-
-          long timeStamp = Long.valueOf(properties.getProperty(MAPREDUCE_SUBMIT_TIME));
-
-          return timeStamp;
+          if (properties.containsKey(MAPREDUCE_SUBMIT_TIME)) {
+            return Long.valueOf(properties.getProperty(MAPREDUCE_SUBMIT_TIME));
+          }
         } finally {
           if (fin != null) {
             fin.close();

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
@@ -151,7 +151,9 @@ public class CamusHourlySweeper extends CamusSweeper {
     // delete existing state file
     for (FileStatus status : fs.listStatus(folder)) {
       if (!status.isDir() && status.getPath().getName().equals(STATE_FILE_NAME)) {
-        fs.delete(status.getPath(), false);
+        if (!fs.delete(status.getPath(), false)) {
+          throw new IOException("Failed to delete state file " + status.getPath());
+        }
       }
     }
 

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeper.java
@@ -233,7 +233,7 @@ public class CamusHourlySweeper extends CamusSweeper {
     public Void call() throws IOException {
       String inputPaths = this.props.getProperty(CamusHourlySweeper.INPUT_PATHS);
       String outputPathStr = this.props.getProperty(CamusHourlySweeper.DEST_PATH);
-      long destinationModTime = getDestinationModTime(outputPathStr);
+      long destinationModTime = getDestinationModTime(this.fs, outputPathStr, true);
       Path outputPath = new Path(outputPathStr, "outlier");
       fs.mkdirs(outputPath);
 
@@ -260,25 +260,30 @@ public class CamusHourlySweeper extends CamusSweeper {
       return null;
     }
 
-    /**
-     * If the destination folder already exist, get the timestamp when the MapReduce job was submitted
-     * to create that folder. The timestamp is stored in a _{timestamp} file.
-     *
-     * If such a file doesn't exist, return the timestamp of the folder.
-     * @throws IOException 
-     */
-    private long getDestinationModTime(String outputPathStr) throws IOException {
-      for (FileStatus status : fs.listStatus(new Path(outputPathStr))) {
-        if (!status.isDir() && status.getPath().getName().matches("_\\d+")) {
-          LOG.info("Found timestamp file: " + status.getPath());
-          long timeStamp = Long.valueOf(status.getPath().getName().substring(1));
-          fs.delete(status.getPath(), false);
-          return timeStamp;
-        }
-      }
+  }
 
-      //return the timestamp of the folder
-      return fs.getFileStatus(new Path(outputPathStr)).getModificationTime();
+  /**
+   * If the destination folder already exist, get the timestamp when the MapReduce job was submitted
+   * to create that folder. The timestamp is stored in a _{timestamp} file.
+   *
+   * If such a file doesn't exist, return the timestamp of the folder.
+   * @throws IOException 
+   */
+  public static long getDestinationModTime(FileSystem fs, String outputPathStr, boolean deleteTimestamp)
+      throws IOException {
+    for (FileStatus status : fs.listStatus(new Path(outputPathStr))) {
+      if (!status.isDir() && status.getPath().getName().matches("_\\d+")) {
+        LOG.info("Found timestamp file: " + status.getPath());
+        long timeStamp = Long.valueOf(status.getPath().getName().substring(1));
+
+        if (deleteTimestamp) {
+          fs.delete(status.getPath(), false);
+        }
+        return timeStamp;
+      }
     }
+
+    //return the timestamp of the folder
+    return fs.getFileStatus(new Path(outputPathStr)).getModificationTime();
   }
 }

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlanner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlanner.java
@@ -114,7 +114,7 @@ public class CamusHourlySweeperPlanner extends CamusSweeperPlanner {
   }
 
   private boolean sourceDirHasOutliers(FileSystem fs, List<Path> sourcePaths, Path destPath) throws IOException {
-    long destinationModTime = fs.getFileStatus(destPath).getModificationTime();
+    long destinationModTime = CamusHourlySweeper.getDestinationModTime(fs, destPath.toString(), false);
     for (Path source : sourcePaths) {
       for (FileStatus status : fs.globStatus(new Path(source, "*"), new HiddenFilter())) {
         if (status.getModificationTime() > destinationModTime) {

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlanner.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusHourlySweeperPlanner.java
@@ -114,7 +114,7 @@ public class CamusHourlySweeperPlanner extends CamusSweeperPlanner {
   }
 
   private boolean sourceDirHasOutliers(FileSystem fs, List<Path> sourcePaths, Path destPath) throws IOException {
-    long destinationModTime = CamusHourlySweeper.getDestinationModTime(fs, destPath.toString(), false);
+    long destinationModTime = CamusHourlySweeper.getDestinationModTime(fs, destPath.toString());
     for (Path source : sourcePaths) {
       for (FileStatus status : fs.globStatus(new Path(source, "*"), new HiddenFilter())) {
         if (status.getModificationTime() > destinationModTime) {


### PR DESCRIPTION
Originally the outliers are identifyed by comparing the timestamp of each avro file in the source folder, and the timestamp of the destination folder. If a source file's timestamp > destination folder's timestamp, it means this source file arrived after destination folder was created, and thus it is considered an outlier.

However, an outlier may arrive after the sweeper mappers start, and BEFORE the destination folder is created. Such an outlier will not be processed by the sweeper, and also will not be identified as outliers in the subsequent run, since its timestamp is < destination folder timestamp.

The solution is to write the sweeper MapReduce job start timestamp in the destination folder as a hidden file, e.g., /data/tracking/PageViewEvent/daily/2015/04/08/_1428543552406. This timestamp will be used to identify outliers.