### PR TITLE
Single Folder Compaction

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -14,13 +14,11 @@ import com.linkedin.camus.schemaregistry.SchemaNotFoundException;
 import java.io.IOException;
 import java.util.HashSet;
 
-import org.apache.hadoop.fs.ChecksumException;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.Mapper;
-import org.apache.hadoop.mapreduce.Mapper.Context;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.log4j.Logger;
@@ -193,7 +191,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
   public boolean nextKeyValue() throws IOException, InterruptedException {
 
     if (System.currentTimeMillis() > maxPullTime) {
-      String maxMsg = "at " + new DateTime(curTimeStamp).toString();
+      String maxMsg = " at " + new DateTime(curTimeStamp).toString();
       log.info("Kafka pull time limit reached");
       statusMsg += " max read " + maxMsg;
       context.setStatus(statusMsg);

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -71,16 +71,15 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
    * @throws IOException
    * @throws InterruptedException
    */
-  public EtlRecordReader(EtlInputFormat inputFormat, InputSplit split, TaskAttemptContext context) 
-      throws IOException, InterruptedException {
+  public EtlRecordReader(EtlInputFormat inputFormat, InputSplit split, TaskAttemptContext context) throws IOException,
+      InterruptedException {
     this.inputFormat = inputFormat;
     initialize(split, context);
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @Override
-  public void initialize(InputSplit split, TaskAttemptContext context) 
-      throws IOException, InterruptedException {
+  public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
     // For class path debugging
     log.info("classpath: " + System.getProperty("java.class.path"));
     ClassLoader loader = EtlRecordReader.class.getClassLoader();
@@ -292,7 +291,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
             log.info(key.getTopic() + " begin read at " + time.toString());
             endTimeStamp = (time.plusHours(this.maxPullHours)).getMillis();
           } else if (curTimeStamp > endTimeStamp) {
-            String maxMsg = "at " + new DateTime(curTimeStamp).toString();
+            String maxMsg = " at " + new DateTime(curTimeStamp).toString();
             log.info("Kafka Max history hours reached");
             mapperContext.write(key, new ExceptionWritable("Topic not fully pulled, max partition hours reached"
                 + maxMsg));

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -1,5 +1,18 @@
 package com.linkedin.camus.etl.kafka.mapred;
 
+import java.io.IOException;
+import java.util.HashSet;
+
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
+
 import com.linkedin.camus.coders.CamusWrapper;
 import com.linkedin.camus.coders.Message;
 import com.linkedin.camus.coders.MessageDecoder;
@@ -10,22 +23,6 @@ import com.linkedin.camus.etl.kafka.common.EtlRequest;
 import com.linkedin.camus.etl.kafka.common.ExceptionWritable;
 import com.linkedin.camus.etl.kafka.common.KafkaReader;
 import com.linkedin.camus.schemaregistry.SchemaNotFoundException;
-
-import kafka.message.Message;
-
-import java.io.IOException;
-import java.util.HashSet;
-
-import org.apache.hadoop.fs.ChecksumException;
-import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.mapreduce.InputSplit;
-import org.apache.hadoop.mapreduce.JobContext;
-import org.apache.hadoop.mapreduce.Mapper;
-import org.apache.hadoop.mapreduce.RecordReader;
-import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.log4j.Logger;
-import org.joda.time.DateTime;
 
 
 public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
@@ -74,16 +71,15 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
    * @throws IOException
    * @throws InterruptedException
    */
-  public EtlRecordReader(EtlInputFormat inputFormat, InputSplit split, TaskAttemptContext context) 
-      throws IOException, InterruptedException {
+  public EtlRecordReader(EtlInputFormat inputFormat, InputSplit split, TaskAttemptContext context) throws IOException,
+      InterruptedException {
     this.inputFormat = inputFormat;
     initialize(split, context);
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @Override
-  public void initialize(InputSplit split, TaskAttemptContext context) 
-      throws IOException, InterruptedException {
+  public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
     // For class path debugging
     log.info("classpath: " + System.getProperty("java.class.path"));
     ClassLoader loader = EtlRecordReader.class.getClassLoader();

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -1,18 +1,5 @@
 package com.linkedin.camus.etl.kafka.mapred;
 
-import java.io.IOException;
-import java.util.HashSet;
-
-import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.mapreduce.InputSplit;
-import org.apache.hadoop.mapreduce.JobContext;
-import org.apache.hadoop.mapreduce.Mapper;
-import org.apache.hadoop.mapreduce.RecordReader;
-import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.log4j.Logger;
-import org.joda.time.DateTime;
-
 import com.linkedin.camus.coders.CamusWrapper;
 import com.linkedin.camus.coders.Message;
 import com.linkedin.camus.coders.MessageDecoder;
@@ -23,6 +10,21 @@ import com.linkedin.camus.etl.kafka.common.EtlRequest;
 import com.linkedin.camus.etl.kafka.common.ExceptionWritable;
 import com.linkedin.camus.etl.kafka.common.KafkaReader;
 import com.linkedin.camus.schemaregistry.SchemaNotFoundException;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+import org.apache.hadoop.fs.ChecksumException;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Mapper.Context;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
 
 
 public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
@@ -71,15 +73,16 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
    * @throws IOException
    * @throws InterruptedException
    */
-  public EtlRecordReader(EtlInputFormat inputFormat, InputSplit split, TaskAttemptContext context) throws IOException,
-      InterruptedException {
+  public EtlRecordReader(EtlInputFormat inputFormat, InputSplit split, TaskAttemptContext context) 
+      throws IOException, InterruptedException {
     this.inputFormat = inputFormat;
     initialize(split, context);
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @Override
-  public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+  public void initialize(InputSplit split, TaskAttemptContext context) 
+      throws IOException, InterruptedException {
     // For class path debugging
     log.info("classpath: " + System.getProperty("java.class.path"));
     ClassLoader loader = EtlRecordReader.class.getClassLoader();
@@ -291,7 +294,7 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
             log.info(key.getTopic() + " begin read at " + time.toString());
             endTimeStamp = (time.plusHours(this.maxPullHours)).getMillis();
           } else if (curTimeStamp > endTimeStamp) {
-            String maxMsg = " at " + new DateTime(curTimeStamp).toString();
+            String maxMsg = "at " + new DateTime(curTimeStamp).toString();
             log.info("Kafka Max history hours reached");
             mapperContext.write(key, new ExceptionWritable("Topic not fully pulled, max partition hours reached"
                 + maxMsg));

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/CamusSweeper.java
@@ -384,7 +384,7 @@ public class CamusSweeper extends Configured implements Tool {
     }
 
     private void moveExistingContentInOutputPathToOldPath(Path oldPath) throws IOException {
-      log.info("Path " + outputPath + " exists. Overwriting.");
+      log.info("Path " + outputPath + " exists. Overwriting. Existing content will be moved to " + oldPath);
       if (!fs.rename(outputPath, oldPath)) {
         fs.delete(tmpPath, true);
         throw new RuntimeException("Error: cannot rename " + outputPath + " to " + oldPath);

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/mapreduce/CamusSweeperAvroKeyJob.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/mapreduce/CamusSweeperAvroKeyJob.java
@@ -76,13 +76,13 @@ public class CamusSweeperAvroKeyJob extends CamusSweeperJob {
     } else {
       keySchema = RelaxedSchemaUtils.parseSchema(keySchemaStr, job.getConfiguration());
 
-      keySchema = duplicateRecord(keySchema, schema);
+      //keySchema = duplicateRecord(keySchema, schema);
 
-      if (!validateKeySchema(schema, keySchema)) {
-        log.info("topic:" + topic + " key invalid, using map only job");
-        job.setNumReduceTasks(0);
-        keySchema = schema;
-      }
+//      if (!validateKeySchema(schema, keySchema)) {
+//        log.info("topic:" + topic + " key invalid, using map only job");
+//        job.setNumReduceTasks(0);
+//        keySchema = schema;
+//      }
     }
 
     setupSchemas(topic, job, schema, keySchema);

--- a/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/mapreduce/CamusSweeperAvroKeyJob.java
+++ b/camus-sweeper/src/main/java/com/linkedin/camus/sweeper/mapreduce/CamusSweeperAvroKeyJob.java
@@ -70,19 +70,23 @@ public class CamusSweeperAvroKeyJob extends CamusSweeperJob {
     String keySchemaStr = getConfValue(job, topic, "camus.sweeper.avro.key.schema");
 
     Schema keySchema;
-    if (keySchemaStr == null || keySchemaStr.isEmpty() || job.getConfiguration().getBoolean("second.stage", false)) {
+    if (job.getConfiguration().getBoolean("camus.sweeper.use.all.attributes", false)) {
+      log.info("Using all attributes in the schema (except Map fields) for deduping");
+      keySchema = getAllFieldsExceptMap(schema);
+    } else if (keySchemaStr == null || keySchemaStr.isEmpty()
+        || job.getConfiguration().getBoolean("second.stage", false)) {
       job.setNumReduceTasks(0);
       keySchema = schema;
     } else {
       keySchema = RelaxedSchemaUtils.parseSchema(keySchemaStr, job.getConfiguration());
 
-      //keySchema = duplicateRecord(keySchema, schema);
+      keySchema = duplicateRecord(keySchema, schema);
 
-//      if (!validateKeySchema(schema, keySchema)) {
-//        log.info("topic:" + topic + " key invalid, using map only job");
-//        job.setNumReduceTasks(0);
-//        keySchema = schema;
-//      }
+      if (!validateKeySchema(schema, keySchema)) {
+        log.info("topic:" + topic + " key invalid, using map only job");
+        job.setNumReduceTasks(0);
+        keySchema = schema;
+      }
     }
 
     setupSchemas(topic, job, schema, keySchema);
@@ -90,6 +94,19 @@ public class CamusSweeperAvroKeyJob extends CamusSweeperJob {
     // setting the compression level. Only used if compression is enabled. default is 6
     job.getConfiguration().setInt(AvroOutputFormat.DEFLATE_LEVEL_KEY,
         job.getConfiguration().getInt(AvroOutputFormat.DEFLATE_LEVEL_KEY, 6));
+  }
+
+  private Schema getAllFieldsExceptMap(Schema schema) {
+    List<Field> fields = new ArrayList<Schema.Field>();
+    for (Field f : schema.getFields()) {
+      if (f.schema().getType() != Schema.Type.MAP) {
+        fields.add(new Field(f.name(), f.schema(), f.doc(), f.defaultValue(), f.order()));
+      }
+    }
+
+    Schema newSchema = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getName(), false);
+    newSchema.setFields(fields);
+    return newSchema;
   }
 
   private boolean validateKeySchema(Schema schema, Schema keySchema) {

--- a/camus-sweeper/src/test/java/com/linkedin/camus/sweeper/CamusSingleFolderSweeperPlannerTest.java
+++ b/camus-sweeper/src/test/java/com/linkedin/camus/sweeper/CamusSingleFolderSweeperPlannerTest.java
@@ -19,7 +19,7 @@ import com.linkedin.camus.sweeper.utils.DateUtils;
 import static org.junit.Assert.*;
 
 
-public class CamusHourlySweeperPlannerTest extends EasyMockSupport {
+public class CamusSingleFolderSweeperPlannerTest extends EasyMockSupport {
   @Test
   public void testCreateSweeperJobProps() throws Exception {
     FileSystem mockedFs = createMock(FileSystem.class);
@@ -52,7 +52,7 @@ public class CamusHourlySweeperPlannerTest extends EasyMockSupport {
     String topic = "testTopic";
 
     List<Properties> jobPropsList =
-        new CamusHourlySweeperPlanner().setPropertiesLogger(new Properties(), Logger.getLogger("testLogger"))
+        new CamusSingleFolderSweeperPlanner().setPropertiesLogger(new Properties(), Logger.getLogger("testLogger"))
             .createSweeperJobProps(topic, inputDir, outputDir, mockedFs);
 
     assertEquals(1, jobPropsList.size());
@@ -61,8 +61,8 @@ public class CamusHourlySweeperPlannerTest extends EasyMockSupport {
     String topicAndHour = topic + ":" + hour;
 
     assertEquals(topic, jobProps.getProperty("topic"));
-    assertEquals(topicAndHour, jobProps.getProperty(CamusHourlySweeper.TOPIC_AND_HOUR));
-    assertEquals(inputDirWithHour.toString(), jobProps.getProperty(CamusHourlySweeper.INPUT_PATHS));
-    assertEquals(outputDirWithHour.toString(), jobProps.getProperty(CamusHourlySweeper.DEST_PATH));
+    assertEquals(topicAndHour, jobProps.getProperty(CamusSingleFolderSweeper.TOPIC_AND_HOUR));
+    assertEquals(inputDirWithHour.toString(), jobProps.getProperty(CamusSingleFolderSweeper.INPUT_PATHS));
+    assertEquals(outputDirWithHour.toString(), jobProps.getProperty(CamusSingleFolderSweeper.DEST_PATH));
   }
 }


### PR DESCRIPTION
Refactored CamusHourlySweeper, increased flexibility of deduping a single folder (not necessarily a single hourly folder, but any single folder), by add the following properties:

camus.sweeper.always.reprocess
By default, if the dest dir of a table already exists, camus will not process that table. Setting this to true will force reprocess.

camus.sweeper.use.all.attributes
Use all attributes in the schema for deduping.

camus.single.folder.sweeper.folder.structure
Dedup all daily data: */*/*
Dedup all hourly data: */*/*/*
Only dedup daily data in 2015: 2015/*/*
Hourly data in Apr 2015: 2015/04/*/*
And so on

camus.single.folder.sweeper.max.hours.ago (default: 1)
This is another way to control which folder to dedup.
e.g. If you wish to dedup all folders in the past 30 days, set it to 720.
If it is sufficient to use the previous property to control the time, and this property is not needed, set it to a large value.

camus.hourly.sweeper.min.hours.ago (default: 1)
E.g. If you don’t need to dedup the previous 2 day’s data, set it to 48.

camus.single.folder.sweeper.time.format
daily: YYYY/MM/dd
hourly: YYYY/MM/dd/HH

camus.single.folder.sweeper.timebased
Default is true. If set to false, it will not look for time-based folder structure, and will use `camus.sweeper.source.subdir` and `camus.sweeper.dest.subdir` as the source and dest folder.