### PR TITLE
Fix camus-hourly mapper skew and improve mapper logging

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlKey.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/EtlKey.java
@@ -33,6 +33,7 @@ public class EtlKey implements WritableComparable<EtlKey>, IEtlKey {
   private long time = 0;
   private String server = "";
   private String service = "";
+  private long totalMessageSize = 0;
   private MapWritable partitionMap = new MapWritable();
 
   /**
@@ -151,6 +152,17 @@ public class EtlKey implements WritableComparable<EtlKey>, IEtlKey {
       return ((LongWritable) this.partitionMap.get(key)).get();
     else
       return 1024; //default estimated size
+  }
+
+  public long getTotalMessageSize() {
+    if (this.totalMessageSize == 0) {
+      this.totalMessageSize = this.getMessageSize();
+    }
+    return this.totalMessageSize;
+  }
+
+  public void setTotalMessageSize(long totalMessageSize) {
+    this.totalMessageSize = totalMessageSize;
   }
 
   public void setMessageSize(long messageSize) {

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
@@ -20,7 +20,6 @@ import kafka.javaapi.message.ByteBufferMessageSet;
 import kafka.message.Message;
 import kafka.message.MessageAndOffset;
 
-import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.log4j.Logger;
 
@@ -57,9 +56,8 @@ public class KafkaReader {
   /**
    * Construct using the json representation of the kafka request
    */
-  public KafkaReader(EtlInputFormat inputFormat, TaskAttemptContext context, EtlRequest request, 
-                     int clientTimeout, int fetchBufferSize)
-      throws Exception {
+  public KafkaReader(EtlInputFormat inputFormat, TaskAttemptContext context, EtlRequest request, int clientTimeout,
+      int fetchBufferSize) throws Exception {
     this.fetchBufferSize = fetchBufferSize;
     this.context = context;
 
@@ -79,19 +77,21 @@ public class KafkaReader {
     // read data from queue
 
     URI uri = kafkaRequest.getURI();
-    simpleConsumer =
-        inputFormat.createSimpleConsumer(context, uri.getHost(), uri.getPort());
+    simpleConsumer = inputFormat.createSimpleConsumer(context, uri.getHost(), uri.getPort());
     log.info("Connected to leader " + uri + " beginning reading at offset " + beginOffset + " latest offset="
         + lastOffset);
     fetch();
   }
 
   public boolean hasNext() throws IOException {
-    if (messageIter != null && messageIter.hasNext())
+    if (currentOffset >= lastOffset) {
+      return false;
+    }
+    if (messageIter != null && messageIter.hasNext()) {
       return true;
-    else
+    } else {
       return fetch();
-
+    }
   }
 
   /**
@@ -114,9 +114,7 @@ public class KafkaReader {
       if (payload == null) {
         log.warn("Received message with null message.payload(): " + msgAndOffset);
       }
-      if (key == null) {
-        log.warn("Received message with null message.key(): " + msgAndOffset);
-      }
+
       etlKey.clear();
       etlKey.set(kafkaRequest.getTopic(), kafkaRequest.getLeaderId(), kafkaRequest.getPartition(), currentOffset,
           msgAndOffset.offset() + 1, message.checksum());
@@ -126,7 +124,8 @@ public class KafkaReader {
       currentOffset = msgAndOffset.offset() + 1; // increase offset
       currentCount++; // increase count
 
-      return new KafkaMessage(payload, key, kafkaRequest.getTopic(), kafkaRequest.getPartition(), msgAndOffset.offset(), message.checksum());
+      return new KafkaMessage(payload, key, kafkaRequest.getTopic(), kafkaRequest.getPartition(),
+          msgAndOffset.offset(), message.checksum());
     } else {
       return null;
     }
@@ -141,7 +140,6 @@ public class KafkaReader {
     }
     return bytes;
   }
-
 
   /**
    * Creates a fetch request.
@@ -170,14 +168,15 @@ public class KafkaReader {
     try {
       fetchResponse = simpleConsumer.fetch(fetchRequest);
       if (fetchResponse.hasError()) {
-        String message = "Error Code generated : "
-            + fetchResponse.errorCode(kafkaRequest.getTopic(), kafkaRequest.getPartition()) + "\n";
+        String message =
+            "Error Code generated : " + fetchResponse.errorCode(kafkaRequest.getTopic(), kafkaRequest.getPartition())
+                + "\n";
         throw new RuntimeException(message);
       }
       return processFetchResponse(fetchResponse, tempTime);
     } catch (Exception e) {
-      log.info("Exception generated during fetch for topic " + kafkaRequest.getTopic()
-          + ": " + e.getMessage() + ". Will refresh topic metadata and retry.");
+      log.info("Exception generated during fetch for topic " + kafkaRequest.getTopic() + ": " + e.getMessage()
+          + ". Will refresh topic metadata and retry.");
       return refreshTopicMetadataAndRetryFetch(fetchRequest, tempTime);
     }
   }
@@ -213,9 +212,10 @@ public class KafkaReader {
     TopicMetadata metadata = response.topicsMetadata().get(0);
     for (PartitionMetadata partitionMetadata : metadata.partitionsMetadata()) {
       if (partitionMetadata.partitionId() == kafkaRequest.getPartition()) {
-        simpleConsumer = new SimpleConsumer(partitionMetadata.leader().host(), partitionMetadata.leader().port(),
-            CamusJob.getKafkaTimeoutValue(context), CamusJob.getKafkaBufferSize(context),
-            CamusJob.getKafkaClientName(context));
+        simpleConsumer =
+            new SimpleConsumer(partitionMetadata.leader().host(), partitionMetadata.leader().port(),
+                CamusJob.getKafkaTimeoutValue(context), CamusJob.getKafkaBufferSize(context),
+                CamusJob.getKafkaClientName(context));
         break;
       }
     }

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -387,7 +387,6 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
       }
     });
 
-    log.info("The requests from kafka metadata are: \n" + finalRequests);
     writeRequests(finalRequests, context);
     Map<CamusRequest, EtlKey> offsetKeys = getPreviousOffsets(FileInputFormat.getInputPaths(context), context);
     Set<String> moveLatest = getMoveToLatestTopicsSet(context);

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -23,12 +23,16 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.format.PeriodFormatter;
+import org.joda.time.format.PeriodFormatterBuilder;
 
 
 public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
   private static final String PRINT_MAX_DECODER_EXCEPTIONS = "max.decoder.exceptions.to.print";
   private static final String DEFAULT_SERVER = "server";
   private static final String DEFAULT_SERVICE = "service";
+  private static final int RECORDS_TO_READ_AFTER_TIMEOUT = 5;
 
   public static enum KAFKA_MSG {
     DECODE_SUCCESSFUL,
@@ -44,6 +48,8 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
 
   private long totalBytes;
   private long readBytes = 0;
+  private int numRecordsReadForCurrentPartition = 0;
+  private long bytesReadForCurrentPartition = 0;
 
   private boolean skipSchemaErrors = false;
   private MessageDecoder decoder;
@@ -57,7 +63,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
   private long maxPullTime = 0;
   private long endTimeStamp = 0;
   private long curTimeStamp = 0;
+  private long startTime = 0;
   private HashSet<String> ignoreServerServiceList = null;
+  private PeriodFormatter periodFormatter = null;
 
   private String statusMsg = "";
 
@@ -103,8 +111,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     }
 
     if (EtlInputFormat.getKafkaMaxPullMinutesPerTask(context) != -1) {
-      DateTime now = new DateTime();
-      this.maxPullTime = now.plusMinutes(EtlInputFormat.getKafkaMaxPullMinutesPerTask(context)).getMillis();
+      this.startTime = System.currentTimeMillis();
+      this.maxPullTime =
+          new DateTime(this.startTime).plusMinutes(EtlInputFormat.getKafkaMaxPullMinutesPerTask(context)).getMillis();
     } else {
       this.maxPullTime = Long.MAX_VALUE;
     }
@@ -115,6 +124,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
     }
 
     this.totalBytes = this.split.getLength();
+
+    this.periodFormatter =
+        new PeriodFormatterBuilder().appendMinutes().appendSuffix("m").appendSeconds().appendSuffix("s").toFormatter();
   }
 
   @Override
@@ -189,8 +201,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
   @Override
   public boolean nextKeyValue() throws IOException, InterruptedException {
 
-    if (System.currentTimeMillis() > maxPullTime) {
-      String maxMsg = " at " + new DateTime(curTimeStamp).toString();
+    if (System.currentTimeMillis() > maxPullTime
+        && this.numRecordsReadForCurrentPartition >= RECORDS_TO_READ_AFTER_TIMEOUT) {
+      String maxMsg = "at " + new DateTime(curTimeStamp).toString();
       log.info("Kafka pull time limit reached");
       statusMsg += " max read " + maxMsg;
       context.setStatus(statusMsg);
@@ -198,26 +211,45 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
       mapperContext.getCounter("total", "request-time(ms)").increment(reader.getFetchTime());
       closeReader();
 
-      mapperContext.write(key, new ExceptionWritable("Topic not fully pulled, max task time reached" + maxMsg));
+      String topicNotFullyPulledMsg =
+          String.format("Topic %s:%d not fully pulled, max task time reached %s, pulled %d records", key.getTopic(),
+              key.getPartition(), maxMsg, this.numRecordsReadForCurrentPartition);
+      mapperContext.write(key, new ExceptionWritable(topicNotFullyPulledMsg));
+      log.warn(topicNotFullyPulledMsg);
 
-      EtlRequest request = null;
+      String timeSpentOnPartition =
+          this.periodFormatter.print(new Duration(this.startTime, System.currentTimeMillis()).toPeriod());
+      String timeSpentOnTopicMsg =
+          String.format("Time spent on topic %s:%d = %s", key.getTopic(), key.getPartition(), timeSpentOnPartition);
+      mapperContext.write(key, new ExceptionWritable(timeSpentOnTopicMsg));
+      log.info(timeSpentOnTopicMsg);
 
-      while ((request = (EtlRequest) split.popRequest()) != null) {
-        key.set(request.getTopic(), request.getLeaderId(), request.getPartition(), request.getOffset(),
-            request.getOffset(), 0);
-        mapperContext.write(key, new ExceptionWritable("Topic not fully pulled, max task time reached"));
-      }
-
-      return false;
+      reader = null;
     }
 
     while (true) {
       try {
+
         if (reader == null || !reader.hasNext()) {
+          if (this.numRecordsReadForCurrentPartition != 0) {
+            String timeSpentOnPartition =
+                this.periodFormatter.print(new Duration(this.startTime, System.currentTimeMillis()).toPeriod());
+            log.info("Time spent on this partition = " + timeSpentOnPartition);
+            log.info("Num of records read for this partition = " + this.numRecordsReadForCurrentPartition);
+            log.info("Bytes read for this partition = " + this.bytesReadForCurrentPartition);
+            log.info("Actual avg size for this partition = " + this.bytesReadForCurrentPartition
+                / this.numRecordsReadForCurrentPartition);
+          }
+
           EtlRequest request = (EtlRequest) split.popRequest();
           if (request == null) {
             return false;
           }
+
+          // Reset start time, num of records read and bytes read
+          this.startTime = System.currentTimeMillis();
+          this.numRecordsReadForCurrentPartition = 0;
+          this.bytesReadForCurrentPartition = 0;
 
           if (maxPullHours > 0) {
             endTimeStamp = 0;
@@ -228,7 +260,6 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
           value = null;
           log.info("\n\ntopic:" + request.getTopic() + " partition:" + request.getPartition() + " beginOffset:"
               + request.getOffset() + " estimatedLastOffset:" + request.getLastOffset());
-
           statusMsg += statusMsg.length() > 0 ? "; " : "";
           statusMsg += request.getTopic() + ":" + request.getLeaderId() + ":" + request.getPartition();
           context.setStatus(statusMsg);
@@ -247,6 +278,8 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
         while ((message = reader.getNext(key)) != null) {
           readBytes += key.getMessageSize();
           count++;
+          this.numRecordsReadForCurrentPartition++;
+          this.bytesReadForCurrentPartition += key.getMessageSize();
           context.progress();
           mapperContext.getCounter("total", "data-read").increment(message.getPayload().length);
           mapperContext.getCounter("total", "event-count").increment(1);
@@ -260,11 +293,13 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
           } catch (Exception e) {
             if (exceptionCount < getMaximumDecoderExceptionsToPrint(context)) {
               mapperContext.write(key, new ExceptionWritable(e));
+              log.info(e.getMessage());
               exceptionCount++;
             } else if (exceptionCount == getMaximumDecoderExceptionsToPrint(context)) {
-              exceptionCount = Integer.MAX_VALUE; // Any random value
               log.info("The same exception has occured for more than " + getMaximumDecoderExceptionsToPrint(context)
-                  + " records. All further exceptions will not be printed");
+                  + " records. This partition will be skipped.");
+              exceptionCount = 0;
+              break;
             }
             continue;
           }
@@ -291,10 +326,13 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
             log.info(key.getTopic() + " begin read at " + time.toString());
             endTimeStamp = (time.plusHours(this.maxPullHours)).getMillis();
           } else if (curTimeStamp > endTimeStamp) {
-            String maxMsg = " at " + new DateTime(curTimeStamp).toString();
+            String maxMsg = "at " + new DateTime(curTimeStamp).toString();
             log.info("Kafka Max history hours reached");
-            mapperContext.write(key, new ExceptionWritable("Topic not fully pulled, max partition hours reached"
-                + maxMsg));
+            mapperContext.write(
+                key,
+                new ExceptionWritable(String.format(
+                    "Topic not fully pulled, max task time reached %s, pulled %d records", maxMsg,
+                    this.numRecordsReadForCurrentPartition)));
             statusMsg += " max read " + maxMsg;
             context.setStatus(statusMsg);
             log.info(key.getTopic() + " max read " + maxMsg);

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -297,7 +297,9 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
               exceptionCount++;
             } else if (exceptionCount == getMaximumDecoderExceptionsToPrint(context)) {
               log.info("The same exception has occured for more than " + getMaximumDecoderExceptionsToPrint(context)
-                  + " records. This partition will be skipped.");
+                  + " records. All further exceptions will not be printed");
+            }
+            if (System.currentTimeMillis() > maxPullTime) {
               exceptionCount = 0;
               break;
             }


### PR DESCRIPTION
There were 4 issues in Camus that could cause mapper skew:

-  The biggest one is a bug in calculating avgRecordSize. Camus uses `long`, and calculate the running total size by `currentAvgSize * currentCount`. This is simply wrong. For example, suppose we currently pulled 10000 records, avgSize = 100, so total size = 1million. Then, even if we pull an infinite number of records with size=200 each, the avgRecordSize will still be 100. And if we pull a single record with size < 100, then avgRecordSize will become 99. So, the avgRecordSize will keep decreasing.

The solution is to modify the way the running total size is computed. See `EtlMultiOutputCommitter.addOffset()`.

- There's another bug: say a mapper is responsible for 10 partitions, but it timed out while processing the 5th partition. Then, for the 6th to 10th partitions, the avgMsgSize committed by Camus will be the same as the size of the last record in the 5th partition read by Camus.
The bug is caused by: if Camus times out before reading a partition, it will emit a (EtlKey, ExceptionWritable) pair. The getMessageSize() of the ExceptionWritable object will return the size of the last read record. This pair is used to calculate the avgMsgSize of this partition.

The solution is to force each mapper to pull at least 5 records in each partition assigned to it. See `EtlRecordReader.nextKeyValue()` line 204.

- Camus may pull beyond latestOffset of a partition, if during the pull, new events are added to the partition.

The solution is to only pull to lastestOffest. See `KafkaReader.hasNext()`.

- If events in a partition cannot be decoded, Camus will keep trying to decode the next event, until all events have been consumed. Camus will ignore the 10-min timeout in this case.

The solution is to check for timeout. See `EtlRecordReader.nextKeyValue()` line 302.

Tested on Nertz, skew has largely disappeared. The remaining occasional skew is due to a single large partition, which has to be assigned to a single mapper.


Also improved mapper logging: remove the log msg "Received message with null message.key()", which dominated the mapper log and caused other important msg to be truncated. Added the time spent on each partition, the total bytes read and the avg record size in mapper log. See `EtlRecordReader.nextKeyValue()`.