### PR TITLE
Add parquet avro record writer provider

### DIFF
--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -80,17 +80,22 @@
 			<artifactId>java-dogstatsd-client</artifactId>
 			<version>2.0.8</version>
 		</dependency>
-    <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
-      <version>1.4.3</version>
-    </dependency>
-    <dependency>
-      <groupId>dumbster</groupId>
-      <artifactId>dumbster</artifactId>
-      <version>1.6</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>javax.mail</groupId>
+			<artifactId>mail</artifactId>
+			<version>1.4.3</version>
+		</dependency>
+		<dependency>
+			<groupId>dumbster</groupId>
+			<artifactId>dumbster</artifactId>
+			<version>1.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.twitter</groupId>
+			<artifactId>parquet-avro</artifactId>
+			<version>1.5.0</version>
+		</dependency>
 	</dependencies>
 
 <!-- 	<build> -->

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/AvroParquetFileRecordWriterProvider.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/AvroParquetFileRecordWriterProvider.java
@@ -1,0 +1,66 @@
+package com.linkedin.camus.etl.kafka.common;
+
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.etl.IEtlKey;
+import com.linkedin.camus.etl.RecordWriterProvider;
+import com.linkedin.camus.etl.kafka.mapred.EtlMultiOutputFormat;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import parquet.avro.AvroParquetWriter;
+import parquet.hadoop.metadata.CompressionCodecName;
+
+import java.io.IOException;
+
+public class AvroParquetFileRecordWriterProvider implements RecordWriterProvider {
+  public final static String EXT = ".parquet";
+  public static final String ETL_OUTPUT_PARQUET_DICTIONARY = "etl.output.parquet.dictionary";
+  public static final String ETL_OUTPUT_PARQUET_BLOCK_SIZE = "etl.output.parquet.blocksize";
+  public static final String ETL_OUTPUT_PARQUET_PAGE_SIZE = "etl.output.parquet.pagesize";
+  public static final String ETL_OUTPUT_PARQUET_COMPRESSION_TYPE = "etl.output.parquet.compression";
+
+  protected Boolean dictionaryEnabled;
+  protected int blockSize;
+  protected int pageSize;
+  protected CompressionCodecName compressionCodec;
+
+  @Override
+  public String getFilenameExtension() {
+    return EXT;
+  }
+
+  public AvroParquetFileRecordWriterProvider(TaskAttemptContext context) {
+    Configuration conf = context.getConfiguration();
+    dictionaryEnabled = conf.getBoolean(ETL_OUTPUT_PARQUET_DICTIONARY, true);
+    blockSize = conf.getInt(ETL_OUTPUT_PARQUET_BLOCK_SIZE, AvroParquetWriter.DEFAULT_BLOCK_SIZE);
+    pageSize = conf.getInt(ETL_OUTPUT_PARQUET_PAGE_SIZE, AvroParquetWriter.DEFAULT_PAGE_SIZE);
+    compressionCodec = CompressionCodecName.fromConf(conf.get(ETL_OUTPUT_PARQUET_COMPRESSION_TYPE, "uncompressed"));
+  }
+
+  @Override
+  public RecordWriter<IEtlKey, CamusWrapper> getDataRecordWriter(TaskAttemptContext context, String fileName,
+                                                                 CamusWrapper camusWrapper, FileOutputCommitter committer) throws IOException, InterruptedException {
+    Schema schema = ((GenericRecord) camusWrapper.getRecord()).getSchema();
+    Path path = new Path(committer.getWorkPath(), EtlMultiOutputFormat.getUniqueFile(context, fileName, EXT));
+
+    final AvroParquetWriter<GenericRecord> writer = new AvroParquetWriter<GenericRecord>(
+        path, schema, compressionCodec, blockSize, pageSize, dictionaryEnabled);
+
+    return new RecordWriter<IEtlKey, CamusWrapper>() {
+
+      @Override
+      public void write(IEtlKey iEtlKey, CamusWrapper camusWrapper) throws IOException, InterruptedException {
+        writer.write((GenericRecord) camusWrapper.getRecord());
+      }
+
+      @Override
+      public void close(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+        writer.close();
+      }
+    };
+  }
+}


### PR DESCRIPTION
This is a basic implementation of a Avro to Parquet RecordWriterProvider which is inspired / similar to the `SequenceFileRecordWriterProvider`.
