### PR TITLE
Fix for ArrayIndexOutOfBoundsException exception

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -389,11 +389,12 @@ public class CamusJob extends Configured implements Tool {
       JobClient client = new JobClient(new JobConf(job.getConfiguration()));
 
       TaskCompletionEvent[] tasks = job.getTaskCompletionEvents(0);
-
-      for (TaskReport task : client.getMapTaskReports(tasks[0].getTaskAttemptId().getJobID())) {
-        if (task.getCurrentStatus().equals(TIPStatus.FAILED)) {
-          for (String s : task.getDiagnostics()) {
-            System.err.println("task error: " + s);
+      if (tasks.length > 0) {
+        for (TaskReport task : client.getMapTaskReports(tasks[0].getTaskAttemptId().getJobID())) {
+          if (task.getCurrentStatus().equals(TIPStatus.FAILED)) {
+            for (String s : task.getDiagnostics()) {
+              System.err.println("task error: " + s);
+            }
           }
         }
       }
@@ -746,3 +747,4 @@ public class CamusJob extends Configured implements Tool {
     return job.getConfiguration().get(CAMUS_REPORTER_CLASS, "com.linkedin.camus.etl.kafka.reporter.TimeReporter");
   }
 }
+


### PR DESCRIPTION
```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 0
	at com.linkedin.camus.etl.kafka.CamusJob.run(CamusJob.java:393)
	at com.linkedin.camus.etl.kafka.CamusJob.run(CamusJob.java:235)
	at com.linkedin.camus.etl.kafka.CamusJob.run(CamusJob.java:690)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:70)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:84)
	at com.linkedin.camus.etl.kafka.CamusJob.main(CamusJob.java:645)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.hadoop.util.RunJar.run(RunJar.java:221)
	at org.apache.hadoop.util.RunJar.main(RunJar.java:136)
```