### PR TITLE
Allow s3 as possible output for destination and execution dirs

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/CamusJob.java
@@ -243,12 +243,12 @@ public class CamusJob extends Configured implements Tool {
     if (getLog4jConfigure(job)) {
       DOMConfigurator.configure("log4j.xml");
     }
-    FileSystem fs = FileSystem.get(job.getConfiguration());
-
     log.info("Dir Destination set to: " + EtlMultiOutputFormat.getDestinationPath(job));
 
     Path execBasePath = new Path(props.getProperty(ETL_EXECUTION_BASE_PATH));
     Path execHistory = new Path(props.getProperty(ETL_EXECUTION_HISTORY_PATH));
+
+    FileSystem fs = FileSystem.get(execBasePath.toUri(), job.getConfiguration());
 
     if (!fs.exists(execBasePath)) {
       log.info("The execution base path does not exist. Creating the directory");

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlInputFormat.java
@@ -483,8 +483,8 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
   }
 
   private void writePrevious(Collection<EtlKey> missedKeys, JobContext context) throws IOException {
-    FileSystem fs = FileSystem.get(context.getConfiguration());
     Path output = FileOutputFormat.getOutputPath(context);
+    FileSystem fs = FileSystem.get(output.toUri(), context.getConfiguration());
 
     if (fs.exists(output)) {
       fs.mkdirs(output);
@@ -502,8 +502,8 @@ public class EtlInputFormat extends InputFormat<EtlKey, CamusWrapper> {
   }
 
   protected void writeRequests(List<CamusRequest> requests, JobContext context) throws IOException {
-    FileSystem fs = FileSystem.get(context.getConfiguration());
     Path output = FileOutputFormat.getOutputPath(context);
+    FileSystem fs = FileSystem.get(output.toUri(), context.getConfiguration());
 
     if (fs.exists(output)) {
       fs.mkdirs(output);

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputRecordWriter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlMultiOutputRecordWriter.java
@@ -41,12 +41,12 @@ public class EtlMultiOutputRecordWriter extends RecordWriter<EtlKey, Object> {
       InterruptedException {
     this.context = context;
     this.committer = committer;
+    Path errorPath = new Path(committer.getWorkPath(), EtlMultiOutputFormat.getUniqueFile(context,
+            EtlMultiOutputFormat.ERRORS_PREFIX, ""));
     errorWriter =
         SequenceFile.createWriter(
-            FileSystem.get(context.getConfiguration()),
-            context.getConfiguration(),
-            new Path(committer.getWorkPath(), EtlMultiOutputFormat.getUniqueFile(context,
-                EtlMultiOutputFormat.ERRORS_PREFIX, "")), EtlKey.class, ExceptionWritable.class);
+            FileSystem.get(errorPath.toUri(), context.getConfiguration()),
+            context.getConfiguration(), errorPath, EtlKey.class, ExceptionWritable.class);
 
     if (EtlInputFormat.getKafkaMaxHistoricalDays(context) != -1) {
       int maxDays = EtlInputFormat.getKafkaMaxHistoricalDays(context);

--- a/camus-example/src/main/resources/camus.properties
+++ b/camus-example/src/main/resources/camus.properties
@@ -7,6 +7,7 @@
 camus.job.name=Camus Job
 
 # final top-level data output directory, sub-directory will be dynamically created for each topic pulled
+# to output to s3, set etl.destination.path=s3://<BUCKET_NAME>/path/to/folder
 etl.destination.path=/user/username/topics
 # HDFS location where you want to keep execution files, i.e. offsets, error logs, and count files
 etl.execution.base.path=/user/username/exec

--- a/pom.xml
+++ b/pom.xml
@@ -6,19 +6,6 @@
   <prerequisites>
     <maven>3.0.0</maven>
   </prerequisites>
-  <distributionManagement>
-    <repository>
-      <id>crittercism</id>
-      <name>crittercism-releases</name>
-      <url>http://crittercism.artifactoryonline.com/crittercism/ext-releases-local</url>
-    </repository>
-
-    <snapshotRepository>
-      <id>crittercism</id>
-      <name>crittercism-snapshots</name>
-      <url>http://crittercism.artifactoryonline.com/crittercism/ext-snapshots-local</url>
-    </snapshotRepository>
-  </distributionManagement>
   <groupId>com.linkedin.camus</groupId>
   <artifactId>camus-parent</artifactId>
   <version>0.1.0-SNAPSHOT</version>
@@ -262,26 +249,6 @@
 	    <arg>-J-Djava.awt.headless=true</arg>
 	  </compilerArgs>
 	</configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
-        <executions>
-          <!-- Run shade goal on package phase -->
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
-                </transformer>
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
allow s3 as a possible output dir for etl.destination.path, etl.execution.base.path, etl.execution.history.path.

Did this by changing the relevant FileSystem.get(conf) calls to FileSystem.get(uri, conf).  

Could use some direction on whether this is actually ok to do, and how to proceed with writing tests and such.  As it is, I'm using it to output stuff to s3 myself.  

Edit:  The reason I did this was because I was unable to get the fs.defaultFS or fs.default.name options working.  

I think a second reason, even if the fs.defaultFS stuff did work, is that this way, we are still doing the work in the local fs (hdfs for emr) and then copying data to s3, vs doing all the work in s3.  Thanks @bcotton!  