### PR TITLE
Stop the statsd client in StatsDReporter

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/reporter/StatsdReporter.java
@@ -38,6 +38,7 @@ public class StatsdReporter extends TimeReporter {
           statsd.gauge(counterGroup.getDisplayName() + "." + counter.getDisplayName(), counter.getValue());
         }
       }
+      statsd.stop();
     }
   }
 


### PR DESCRIPTION
The StatsD client used is async, and we have observed
counters not getting reported on a few occasions. Calling
`#stop` allows it to flush the metrics and shutdown cleanly.