### PR TITLE
Camus Sweeper for hadoop2, IncompatibleClassChangeError

### DIFF
--- a/camus-sweeper/pom.xml
+++ b/camus-sweeper/pom.xml
@@ -12,11 +12,19 @@
 		<version>0.1.0-SNAPSHOT</version>
 	</parent>
 
+	<properties>
+		<avro.version>1.7.7</avro.version>
+	</properties>
+
 	<dependencies>
+
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-core</artifactId>
-			<version>1.0.4</version>
+			<artifactId>hadoop-mapreduce-client-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
 		</dependency>
 
 		<dependency>
@@ -27,13 +35,14 @@
 		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro-mapred</artifactId>
-			<version>1.7.7</version>
+			<version>${avro.version}</version>
+			<classifier>hadoop2</classifier>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
-			<version>1.7.7</version>
+			<version>${avro.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
When using camus-sweeper with hadoop2, following error occurs
'org.apache.hadoop.mapred.YarnChild: Error running child : java.lang.IncompatibleClassChangeError: Found interface org.apache.hadoop.mapreduce.TaskAttemptContext, but class was expected', due to avro-mapred dependecy not compiling against hadoop2.

I guess more people using hadoop2, so this should be the default, what do you think?