### PR TITLE
Add expections thrown by null values to maximumDecoderExceptions.

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReader.java
@@ -290,6 +290,10 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
           CamusWrapper wrapper;
           try {
             wrapper = getWrappedRecord(message);
+
+            if (wrapper == null) {
+              throw new RuntimeException("null record");
+            }
           } catch (Exception e) {
             if (exceptionCount < getMaximumDecoderExceptionsToPrint(context)) {
               mapperContext.write(key, new ExceptionWritable(e));
@@ -303,11 +307,6 @@ public class EtlRecordReader extends RecordReader<EtlKey, CamusWrapper> {
               exceptionCount = 0;
               break;
             }
-            continue;
-          }
-
-          if (wrapper == null) {
-            mapperContext.write(key, new ExceptionWritable(new RuntimeException("null record")));
             continue;
           }
 


### PR DESCRIPTION
I moved the null check up into the try block. So that exceptions caused by null values are added to maximumDecoderExceptions. Otherwise these exceptions spam the Hadoop logs.