### PR TITLE
JSONStringMessageDecoder enhancements

### DIFF
--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
@@ -125,10 +125,10 @@ public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
 
       while (timestampField.indexOf('.') != -1) { // go through nested objects
         String field = timestampField.substring(0, timestampField.indexOf('.'));
-        timestampField = timestampField.substring(timestampField.indexOf('.') + 1);
         if (!jsonObject.has(field)) {
           break;
         }
+        timestampField = timestampField.substring(timestampField.indexOf('.') + 1);
         jsonObject = jsonObject.getAsJsonObject(field);
       }
 

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonParser;
 import com.linkedin.camus.coders.CamusWrapper;
 import com.linkedin.camus.coders.Message;
 import com.linkedin.camus.coders.MessageDecoder;
+
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
@@ -13,7 +14,12 @@ import org.joda.time.format.ISODateTimeFormat;
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 /**
@@ -44,19 +50,46 @@ public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
   public static final String CAMUS_MESSAGE_TIMESTAMP_FIELD = "camus.message.timestamp.field";
   public static final String DEFAULT_TIMESTAMP_FIELD = "timestamp";
 
+  public static final Pattern MULTI_TIMESTAMP_PATTERN = Pattern.compile("camus.message.timestamp.([0-9]+).(format|field)");
+
   JsonParser jsonParser = new JsonParser();
   DateTimeFormatter dateTimeParser = ISODateTimeFormat.dateTimeParser();
 
-  private String timestampFormat;
-  private String timestampField;
+  private List<TimestampInfo> possibleTimestamps = new ArrayList<JsonStringMessageDecoder.TimestampInfo>();
 
   @Override
   public void init(Properties props, String topicName) {
     this.props = props;
     this.topicName = topicName;
 
-    timestampFormat = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FORMAT, DEFAULT_TIMESTAMP_FORMAT);
-    timestampField = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FIELD, DEFAULT_TIMESTAMP_FIELD);
+    initPossibleTimestamps(props);
+  }
+
+  private void initPossibleTimestamps(Properties props) {
+    HashMap<Integer, TimestampInfo> configurationMap = new HashMap<Integer, TimestampInfo>();
+
+    for (String key: props.stringPropertyNames()) {
+      Matcher m = MULTI_TIMESTAMP_PATTERN.matcher(key);
+      if (m.matches()) {
+        Integer index = Integer.valueOf(m.group(1));
+        if (!configurationMap.containsKey(index)) {
+          configurationMap.put(index, new TimestampInfo());
+        }
+        TimestampInfo timestampInfo = configurationMap.get(index);
+
+        if ("format".equals(m.group(2))) {
+          timestampInfo.format = props.getProperty(key);
+        } else if ("field".equals(m.group(2))) {
+          timestampInfo.field = props.getProperty(key);
+        }
+      }
+    }
+    possibleTimestamps.addAll(configurationMap.values());
+
+    TimestampInfo timestampInfo = new TimestampInfo();
+    timestampInfo.format = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FORMAT, DEFAULT_TIMESTAMP_FORMAT);
+    timestampInfo.field = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FIELD, DEFAULT_TIMESTAMP_FIELD);
+    possibleTimestamps.add(timestampInfo);
   }
 
   @Override
@@ -64,6 +97,7 @@ public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
     long timestamp = 0;
     String payloadString;
     JsonObject jsonObject;
+    JsonObject jsonObjectOrig;
 
     try {
       payloadString = new String(message.getPayload(), "UTF-8");
@@ -74,49 +108,68 @@ public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
 
     // Parse the payload into a JsonObject.
     try {
-      jsonObject = jsonParser.parse(payloadString.trim()).getAsJsonObject();
+      jsonObjectOrig = jsonParser.parse(payloadString.trim()).getAsJsonObject();
     } catch (RuntimeException e) {
       log.error("Caught exception while parsing JSON string '" + payloadString + "'.");
       throw new RuntimeException(e);
     }
 
-    // Attempt to read and parse the timestamp element into a long.
-    if (jsonObject.has(timestampField)) {
-      // If timestampFormat is 'unix_seconds',
-      // then the timestamp only needs converted to milliseconds.
-      // Also support 'unix' for backwards compatibility.
-      if (timestampFormat.equals("unix_seconds") || timestampFormat.equals("unix")) {
-        timestamp = jsonObject.get(timestampField).getAsLong();
-        // This timestamp is in seconds, convert it to milliseconds.
-        timestamp = timestamp * 1000L;
+    for (TimestampInfo timestampInfo: possibleTimestamps) {
+      if (timestamp != 0) { // timestamp already decoded
+        break;
       }
-      // Else if this timestamp is already in milliseconds,
-      // just save it as is.
-      else if (timestampFormat.equals("unix_milliseconds")) {
-        timestamp = jsonObject.get(timestampField).getAsLong();
-      }
-      // Else if timestampFormat is 'ISO-8601', parse that
-      else if (timestampFormat.equals("ISO-8601")) {
-        String timestampString = jsonObject.get(timestampField).getAsString();
-        try {
-          timestamp = new DateTime(timestampString).getMillis();
-        } catch (IllegalArgumentException e) {
-          log.error("Could not parse timestamp '" + timestampString + "' as ISO-8601 while decoding JSON message.");
+
+      String timestampField = timestampInfo.field;
+      String timestampFormat = timestampInfo.format;
+      jsonObject = jsonObjectOrig;
+
+      while (timestampField.indexOf('.') != -1) { // go through nested objects
+        String field = timestampField.substring(0, timestampField.indexOf('.'));
+        timestampField = timestampField.substring(timestampField.indexOf('.') + 1);
+        if (!jsonObject.has(field)) {
+          break;
         }
+        jsonObject = jsonObject.getAsJsonObject(field);
       }
-      // Otherwise parse the timestamp as a string in timestampFormat.
-      else {
-        String timestampString = jsonObject.get(timestampField).getAsString();
-        try {
-          timestamp = dateTimeParser.parseDateTime(timestampString).getMillis();
-        } catch (IllegalArgumentException e) {
+
+      // Attempt to read and parse the timestamp element into a long.
+      if (jsonObject.has(timestampField)) {
+        // If timestampFormat is 'unix_seconds',
+        // then the timestamp only needs converted to milliseconds.
+        // Also support 'unix' for backwards compatibility.
+        if (timestampFormat.equals("unix_seconds") || timestampFormat.equals("unix")) {
+          timestamp = jsonObject.get(timestampField).getAsLong();
+          // This timestamp is in seconds, convert it to milliseconds.
+          timestamp = timestamp * 1000L;
+        }
+        // Else if this timestamp is already in milliseconds,
+        // just save it as is.
+        else if (timestampFormat.equals("unix_milliseconds")) {
+          timestamp = jsonObject.get(timestampField).getAsLong();
+        }
+        // Else if timestampFormat is 'ISO-8601', parse that
+        else if (timestampFormat.equals("ISO-8601")) {
+          String timestampString = jsonObject.get(timestampField).getAsString();
           try {
-            timestamp = new SimpleDateFormat(timestampFormat).parse(timestampString).getTime();
-          } catch (ParseException pe) {
+            timestamp = new DateTime(timestampString).getMillis();
+          } catch (IllegalArgumentException e) {
+            log.error("Could not parse timestamp '" + timestampString + "' as ISO-8601 while decoding JSON message.");
+          }
+        }
+        // Otherwise parse the timestamp as a string in timestampFormat.
+        else {
+          String timestampString = jsonObject.get(timestampField).getAsString();
+          try {
+            timestamp = dateTimeParser.parseDateTime(timestampString).getMillis();
+          } catch (IllegalArgumentException e) {
+            try {
+              timestamp = new SimpleDateFormat(timestampFormat).parse(timestampString).getTime();
+            } catch (ParseException pe) {
+              log.error("Could not parse timestamp '" + timestampString + "' while decoding JSON message.");
+            }
+          } catch (Exception ee) {
             log.error("Could not parse timestamp '" + timestampString + "' while decoding JSON message.");
           }
-        } catch (Exception ee) {
-          log.error("Could not parse timestamp '" + timestampString + "' while decoding JSON message.");
         }
       }
     }
@@ -124,11 +177,21 @@ public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
     // If timestamp wasn't set in the above block,
     // then set it to current time.
     if (timestamp == 0) {
-      log.warn("Couldn't find or parse timestamp field '" + timestampField
+      log.warn("Couldn't find or parse timestamp fields '" + possibleTimestamps
           + "' in JSON message, defaulting to current time.");
       timestamp = System.currentTimeMillis();
     }
 
     return new CamusWrapper<String>(payloadString, timestamp);
+  }
+
+  static class TimestampInfo {
+    public String format;
+    public String field;
+
+    @Override
+    public String toString() {
+      return field + " (" + format + ")";
+    }
   }
 }


### PR DESCRIPTION
Current implementation of JsonStringMessageDecoder allows only one field as timestamp source - if there are more than one kind of input source with different timestamping schema it does not partition messages well. In addition, field for timestamp decoding must be available in parent JSON of message.

This pull request allows to pass multiple formats of timestamp field (also nested fields) like:

    camus.message.timestamp.1.field=EventReceivedTime
    camus.message.timestamp.1.format=yyyy-MM-dd HH:mm:ss
    camus.message.timestamp.2.field=metadata.timestamp
    camus.message.timestamp.2.format=unix_milliseconds
