### PR TITLE
StringRecordWriter support more compression libraries. New decoder to support Plain string messages

### DIFF
--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/StringRecordWriterProvider.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/StringRecordWriterProvider.java
@@ -32,6 +32,8 @@ import org.apache.log4j.Logger;
 public class StringRecordWriterProvider implements RecordWriterProvider {
   public static final String ETL_OUTPUT_RECORD_DELIMITER = "etl.output.record.delimiter";
   public static final String DEFAULT_RECORD_DELIMITER = "\n";
+  
+  private static Logger log = Logger.getLogger(StringRecordWriterProvider.class);
 
   protected String recordDelimiter = null;
 
@@ -50,13 +52,25 @@ public class StringRecordWriterProvider implements RecordWriterProvider {
 
     if (isCompressed) {
       Class<? extends CompressionCodec> codecClass = null;
-      if ("snappy".equals(EtlMultiOutputFormat.getEtlOutputCodec(context))) {
-        codecClass = SnappyCodec.class;
-      } else if ("gzip".equals((EtlMultiOutputFormat.getEtlOutputCodec(context)))) {
-        codecClass = GzipCodec.class;
-      } else {
-        codecClass = DefaultCodec.class;
-      }
+      
+      try {
+		Class<?> compressionClass = Class.forName(EtlMultiOutputFormat.getEtlOutputCodec(context));
+
+		if(CompressionCodec.class.isAssignableFrom(compressionClass)){
+			codecClass = (Class<? extends CompressionCodec>) compressionClass;
+		}
+		else{
+			log.warn("Codec class" + EtlMultiOutputFormat.getEtlOutputCodec(context)
+	    	  		+ " is not a valid compression class, using DefaultCodec");
+			codecClass = DefaultCodec.class;
+		}
+      } catch (ClassNotFoundException e) {
+    	  log.warn("Codec class" + EtlMultiOutputFormat.getEtlOutputCodec(context)
+    	  		+ " not found, using DefaultCodec to compress data.");
+    	  e.printStackTrace();
+    	  codecClass = DefaultCodec.class;
+    }
+      
       codec = ReflectionUtils.newInstance(codecClass, conf);
       extension = codec.getDefaultExtension();
     }

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/StringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/StringMessageDecoder.java
@@ -1,0 +1,50 @@
+package com.linkedin.camus.etl.kafka.coders;
+
+import java.util.Properties;
+
+import com.linkedin.camus.coders.Message;
+import com.linkedin.camus.coders.CamusWrapper;
+import com.linkedin.camus.coders.MessageDecoder;
+import java.io.UnsupportedEncodingException;
+
+import org.apache.log4j.Logger;
+
+/**
+ * MessageDecoder class that will convert the payload into a String object,
+ * look for a field named 'timestamp', and then set the CamusWrapper's
+ * timestamp property to the record's timestamp. System.currentTimeMillis() is used.
+ * This MessageDecoder returns a CamusWrapper that works with Strings payloads.
+ * 
+ * @author Marcelo Valle (mvalle@keedio.com https://github.com/keedio)
+ * 
+ */
+
+
+public class StringMessageDecoder extends MessageDecoder<Message, String> {
+
+	private static final org.apache.log4j.Logger log = Logger.getLogger(StringMessageDecoder.class);
+
+	@Override
+	public void init(Properties props, String topicName) {
+		this.props     = props;
+		this.topicName = topicName;
+	}
+
+	@Override
+	public CamusWrapper<String> decode(Message message) {
+		long timestamp = 0;
+		String payloadString;
+    		
+		try {
+			payloadString = new String(message.getPayload(), "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			log.error("Unable to load UTF-8 encoding, falling back to system default", e);
+			payloadString = new String(message.getPayload());
+		}
+
+		// Set the timestamp to current time.
+		timestamp = System.currentTimeMillis();
+
+		return new CamusWrapper<String>(payloadString, timestamp);
+	}
+}


### PR DESCRIPTION
StringRecordWriter now support more compression codecs than snappy, gzip and deflate.
etl.output.codec configuration property must content complete qualified class name
```properties
etl.output.codec=com.hadoop.compression.lzo.LzopCodec
```

New decoder to support Kafka plain string messages. Configuration property:
````properties
camus.message.decoder.class=com.linkedin.camus.etl.kafka.coders.StringMessageDecoder
```