### PR TITLE
CamusWrapper changed to mutable object.

### DIFF
--- a/camus-api/src/main/java/com/linkedin/camus/coders/CamusWrapper.java
+++ b/camus-api/src/main/java/com/linkedin/camus/coders/CamusWrapper.java
@@ -13,24 +13,34 @@ import org.apache.hadoop.io.Writable;
  * @param <R> The type of decoded payload
  */
 public class CamusWrapper<R> {
+    public static final Text SERVER = new Text("server");
+    public static final Text SERVICE = new Text("service");
+
+    public static final Text DEFAULT_SERVER = new Text("unknown_server");
+    public static final Text DEFAULT_SERVICE = new Text("unknown_service");
+
     private R record;
     private long timestamp;
-    private MapWritable partitionMap;
+    private final MapWritable partitionMap = new MapWritable();
 
-    public CamusWrapper(R record) {
-        this(record, System.currentTimeMillis());
+    public CamusWrapper() {
+        super();
     }
 
-    public CamusWrapper(R record, long timestamp) {
-        this(record, timestamp, "unknown_server", "unknown_service");
+    public void set(R record) {
+        this.set(record, System.currentTimeMillis());
     }
 
-    public CamusWrapper(R record, long timestamp, String server, String service) {
+    public void set(R record, long timestamp) {
+        this.set(record, timestamp, DEFAULT_SERVER, DEFAULT_SERVICE);
+    }
+
+    public void set(R record, long timestamp, Text server, Text service) {
         this.record = record;
         this.timestamp = timestamp;
-        this.partitionMap = new MapWritable();
-        partitionMap.put(new Text("server"), new Text(server));
-        partitionMap.put(new Text("service"), new Text(service));
+        this.partitionMap.clear();
+        this.partitionMap.put(this.SERVER, server);
+        this.partitionMap.put(this.SERVICE, service);
     }
 
     /**
@@ -38,7 +48,7 @@ public class CamusWrapper<R> {
      * @return
      */
     public R getRecord() {
-        return record;
+        return this.record;
     }
 
     /**
@@ -46,14 +56,14 @@ public class CamusWrapper<R> {
      * @return
      */
     public long getTimestamp() {
-        return timestamp;
+        return this.timestamp;
     }
 
     /**
      * Add a value for partitions
      */
     public void put(Writable key, Writable value) {
-        partitionMap.put(key, value);
+        this.partitionMap.put(key, value);
     }
 
     /**
@@ -61,14 +71,14 @@ public class CamusWrapper<R> {
      * @return the value for the given key
      */
     public Writable get(Writable key) {
-        return partitionMap.get(key);
+        return this.partitionMap.get(key);
     }
 
     /**
      * Get all the partition key/partitionMap
      */
     public MapWritable getPartitionMap() {
-        return partitionMap;
+        return this.partitionMap;
     }
 
 }

--- a/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReaderForUnitTest.java
+++ b/camus-etl-kafka/src/test/java/com/linkedin/camus/etl/kafka/mapred/EtlRecordReaderForUnitTest.java
@@ -44,7 +44,9 @@ public class EtlRecordReaderForUnitTest extends EtlRecordReader {
   public static MessageDecoder createMockDecoder30PercentSchemaNotFound() {
     MessageDecoder mockDecoder = EasyMock.createNiceMock(MessageDecoder.class);
     EasyMock.expect(mockDecoder.decode(EasyMock.anyObject())).andThrow(new SchemaNotFoundException()).times(3);
-    EasyMock.expect(mockDecoder.decode(EasyMock.anyObject())).andReturn(new CamusWrapper<String>("dummy")).times(7);
+    CamusWrapper<String> stringCamusWrapper = new CamusWrapper<String>();
+    stringCamusWrapper.set("dummy");
+    EasyMock.expect(mockDecoder.decode(EasyMock.anyObject())).andReturn(stringCamusWrapper).times(7);
     EasyMock.replay(mockDecoder);
     return mockDecoder;
   }
@@ -52,7 +54,9 @@ public class EtlRecordReaderForUnitTest extends EtlRecordReader {
   public static MessageDecoder createMockDecoder30PercentOther() {
     MessageDecoder mockDecoder = EasyMock.createNiceMock(MessageDecoder.class);
     EasyMock.expect(mockDecoder.decode(EasyMock.anyObject())).andThrow(new RuntimeException()).times(3);
-    EasyMock.expect(mockDecoder.decode(EasyMock.anyObject())).andReturn(new CamusWrapper<String>("dummy")).times(7);
+    CamusWrapper<String> stringCamusWrapper = new CamusWrapper<String>();
+    stringCamusWrapper.set("dummy");
+    EasyMock.expect(mockDecoder.decode(EasyMock.anyObject())).andReturn(stringCamusWrapper).times(7);
     EasyMock.replay(mockDecoder);
     return mockDecoder;
   }

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JSONToAvroMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JSONToAvroMessageDecoder.java
@@ -32,13 +32,13 @@ public class JSONToAvroMessageDecoder extends MessageDecoder<Message, GenericDat
   private static final Logger log = Logger.getLogger(JsonStringMessageDecoder.class);
   public static final String CAMUS_SCHEMA_ID_FIELD = "camus.message.schema.id.field";
   public static final String DEFAULT_SCHEMA_ID_FIELD = "schemaID";
+  private static final CamusWrapper<GenericData.Record> camusWrapper = new CamusWrapper<GenericData.Record>();
   JsonParser jsonParser;
   private String schemaIDField;
   protected DecoderFactory decoderFactory;
   protected SchemaRegistry<Schema> registry;
   private Schema latestSchema;
-  private CamusWrapper<GenericData.Record> camusWrapper;
-  
+
   public JSONToAvroMessageDecoder() {
     this.jsonParser = new JsonParser();
   }
@@ -59,7 +59,6 @@ public class JSONToAvroMessageDecoder extends MessageDecoder<Message, GenericDat
       
       this.registry = new CachedSchemaRegistry<Schema>(registry, props);
       this.latestSchema = ((Schema) registry.getLatestSchemaByTopic(topicName).getSchema());
-      this.camusWrapper = new CamusWrapper<GenericData.Record>();
     } catch (Exception e) {
       throw new MessageDecoderException(e);
     }

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
@@ -49,11 +49,13 @@ public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
 
   private String timestampFormat;
   private String timestampField;
+  private CamusWrapper<String> camusWrapper;
 
   @Override
   public void init(Properties props, String topicName) {
     this.props = props;
     this.topicName = topicName;
+    this.camusWrapper = new CamusWrapper<String>();
 
     timestampFormat = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FORMAT, DEFAULT_TIMESTAMP_FORMAT);
     timestampField = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FIELD, DEFAULT_TIMESTAMP_FIELD);
@@ -129,6 +131,7 @@ public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
       timestamp = System.currentTimeMillis();
     }
 
-    return new CamusWrapper<String>(payloadString, timestamp);
+    this.camusWrapper.set(payloadString, timestamp);
+    return this.camusWrapper;
   }
 }

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonStringMessageDecoder.java
@@ -44,18 +44,18 @@ public class JsonStringMessageDecoder extends MessageDecoder<Message, String> {
   public static final String CAMUS_MESSAGE_TIMESTAMP_FIELD = "camus.message.timestamp.field";
   public static final String DEFAULT_TIMESTAMP_FIELD = "timestamp";
 
+  private static final CamusWrapper<String> camusWrapper = new CamusWrapper<String>();
+
   JsonParser jsonParser = new JsonParser();
   DateTimeFormatter dateTimeParser = ISODateTimeFormat.dateTimeParser();
 
   private String timestampFormat;
   private String timestampField;
-  private CamusWrapper<String> camusWrapper;
 
   @Override
   public void init(Properties props, String topicName) {
     this.props = props;
     this.topicName = topicName;
-    this.camusWrapper = new CamusWrapper<String>();
 
     timestampFormat = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FORMAT, DEFAULT_TIMESTAMP_FORMAT);
     timestampField = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FIELD, DEFAULT_TIMESTAMP_FIELD);

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonWrappedStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonWrappedStringMessageDecoder.java
@@ -45,12 +45,13 @@ public class JsonWrappedStringMessageDecoder extends MessageDecoder<Message, Str
   public static final String CAMUS_MESSAGE_TIMESTAMP_FIELD = "camus.message.timestamp.field";
   public static final String DEFAULT_TIMESTAMP_FIELD = "timestamp";
 
+  private static final CamusWrapper<String> camusWrapper = new CamusWrapper<String>();
+
   JsonParser jsonParser = new JsonParser();
   DateTimeFormatter dateTimeParser = ISODateTimeFormat.dateTimeParser();
 
   private String timestampFormat;
   private String timestampField;
-  private CamusWrapper<String> camusWrapper;
 
   @Override
   public void init(Properties props, String topicName) {
@@ -59,8 +60,6 @@ public class JsonWrappedStringMessageDecoder extends MessageDecoder<Message, Str
 
     timestampFormat = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FORMAT, DEFAULT_TIMESTAMP_FORMAT);
     timestampField = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FIELD, DEFAULT_TIMESTAMP_FIELD);
-
-    this.camusWrapper = new CamusWrapper<String>();
   }
 
   @Override

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonWrappedStringMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/JsonWrappedStringMessageDecoder.java
@@ -50,7 +50,7 @@ public class JsonWrappedStringMessageDecoder extends MessageDecoder<Message, Str
 
   private String timestampFormat;
   private String timestampField;
-
+  private CamusWrapper<String> camusWrapper;
 
   @Override
   public void init(Properties props, String topicName) {
@@ -59,6 +59,8 @@ public class JsonWrappedStringMessageDecoder extends MessageDecoder<Message, Str
 
     timestampFormat = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FORMAT, DEFAULT_TIMESTAMP_FORMAT);
     timestampField = props.getProperty(CAMUS_MESSAGE_TIMESTAMP_FIELD, DEFAULT_TIMESTAMP_FIELD);
+
+    this.camusWrapper = new CamusWrapper<String>();
   }
 
   @Override
@@ -80,7 +82,8 @@ public class JsonWrappedStringMessageDecoder extends MessageDecoder<Message, Str
 
     messageJsonObject.addProperty("timestamp", timestamp);
 
-    return new CamusWrapper<String>(messageJsonObject.toString(), timestamp);
+    this.camusWrapper.set(messageJsonObject.toString(), timestamp);
+    return this.camusWrapper;
   }
 
   private JsonObject toJson(byte[] bytes) {

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/KafkaAvroMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/KafkaAvroMessageDecoder.java
@@ -23,11 +23,11 @@ public class KafkaAvroMessageDecoder extends MessageDecoder<Message, Record> {
   private static final Logger log = Logger.getLogger(KafkaAvroMessageDecoder.class);
   public static final Text SERVER = new Text("server");
   public static final Text SERVICE = new Text("service");
+  protected static final CamusWrapper<Record> camusWrapper = new CamusAvroWrapper();
 
   protected DecoderFactory decoderFactory;
   protected SchemaRegistry<Schema> registry;
   private Schema latestSchema;
-  protected CamusWrapper<Record> camusWrapper;
 
   @Override
   public void init(Properties props, String topicName) {
@@ -43,7 +43,6 @@ public class KafkaAvroMessageDecoder extends MessageDecoder<Message, Record> {
 
       this.registry = new CachedSchemaRegistry<Schema>(registry, props);
       this.latestSchema = registry.getLatestSchemaByTopic(topicName).getSchema();
-      this.camusWrapper = new CamusAvroWrapper();
 
     } catch (Exception e) {
       throw new MessageDecoderException(e);

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/KafkaAvroMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/KafkaAvroMessageDecoder.java
@@ -43,7 +43,7 @@ public class KafkaAvroMessageDecoder extends MessageDecoder<Message, Record> {
 
       this.registry = new CachedSchemaRegistry<Schema>(registry, props);
       this.latestSchema = registry.getLatestSchemaByTopic(topicName).getSchema();
-      this.camusWrapper = new CamusWrapper<Record>();
+      this.camusWrapper = new CamusAvroWrapper();
 
     } catch (Exception e) {
       throw new MessageDecoderException(e);

--- a/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/LatestSchemaKafkaAvroMessageDecoder.java
+++ b/camus-kafka-coders/src/main/java/com/linkedin/camus/etl/kafka/coders/LatestSchemaKafkaAvroMessageDecoder.java
@@ -21,9 +21,11 @@ public class LatestSchemaKafkaAvroMessageDecoder extends KafkaAvroMessageDecoder
 
       reader.setSchema(schema);
 
-      return new CamusWrapper<Record>(reader.read(null, decoderFactory.jsonDecoder(schema, new String(message.getPayload(),
-      //Message.payloadOffset(message.magic()),
-          kafka.message.Message.MagicOffset(), message.getPayload().length - kafka.message.Message.MagicOffset()))));
+      this.camusWrapper.set(reader.read(null, decoderFactory.jsonDecoder(schema, new String(message.getPayload(),
+              //Message.payloadOffset(message.magic()),
+              kafka.message.Message.MagicOffset(), message.getPayload().length - kafka.message.Message.MagicOffset()))));
+
+      return this.camusWrapper;
     } catch (Exception e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Modified CamusWrapper to be a mutable object to avoid new object creation for every record being pulled out of Kafka.  This improves the decode speed significantly.
